### PR TITLE
feat: Uncorked public event website (fullertonuncorked.org)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,33 +1,41 @@
 # Bryn — Fullerton Rotary Club
-# Copy to .env and fill in values. NEVER commit .env to git.
+# Copy to .env.local and fill in values. NEVER commit .env.local to git.
+#
+# All variables marked [REQUIRED] are validated at startup by src/lib/env.ts.
+# Missing or malformed values will cause an immediate startup error.
 
-# Database — Neon Postgres
+# ─── Database — Neon Postgres ─────────────────────────────────────────────
 # Get from: https://console.neon.tech → your project → Connection Details
+# [REQUIRED] Must start with "postgres"
 DATABASE_URL=postgres://user:pass@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
 
-# Clerk Auth
+# ─── Clerk Auth ───────────────────────────────────────────────────────────
 # Get from: https://dashboard.clerk.com → your app → API Keys
+# [REQUIRED] Must start with "pk_"
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+# [REQUIRED] Must start with "sk_"
 CLERK_SECRET_KEY=sk_test_...
+# [REQUIRED] Clerk redirect URLs (defaults: /login, /register, /portal, /portal)
 NEXT_PUBLIC_CLERK_SIGN_IN_URL=/login
 NEXT_PUBLIC_CLERK_SIGN_UP_URL=/register
 NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/portal
 NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/portal
 
-# OpenClaw / Anthropic
+# ─── Anthropic ────────────────────────────────────────────────────────────
+# [REQUIRED] Must start with "sk-ant-"
 ANTHROPIC_API_KEY=sk-ant-...
 
-# Slack (Datawake workspace — Socket Mode)
+# ─── Slack (Datawake workspace — Socket Mode) [Optional] ─────────────────
 SLACK_BOT_TOKEN=xoxb-...
 SLACK_APP_TOKEN=xapp-...
 
-# ClickUp
+# ─── ClickUp [Optional] ───────────────────────────────────────────────────
 CLICKUP_API_TOKEN=pk_...
 
-# Google (Calendar + Gmail — OAuth)
+# ─── Google (Calendar + Gmail — OAuth) [Optional] ─────────────────────────
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
 # GOOGLE_REFRESH_TOKEN=
 
-# Email (for weekly updates)
-# GMAIL_SEND_AS=bryn@datawake.io
+# ─── App URL (optional — used for invite redirect links) ─────────────────
+# NEXT_PUBLIC_APP_URL=https://yourdomain.com

--- a/app/drizzle.config.ts
+++ b/app/drizzle.config.ts
@@ -1,10 +1,12 @@
 import type { Config } from "drizzle-kit";
+// Import env for validation — drizzle-kit runs on the server (Node.js)
+import { env } from "./src/lib/env";
 
 export default {
   schema: "./src/lib/db/schema.ts",
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url: env.DATABASE_URL,
   },
 } satisfies Config;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -36,7 +36,9 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "recharts": "^3.7.0",
-        "tailwind-merge": "^3.5.0"
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -49,7 +51,7 @@
         "eslint-config-next": "16.1.6",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -10753,6 +10755,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/app/package.json
+++ b/app/package.json
@@ -41,7 +41,9 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",
-    "tailwind-merge": "^3.5.0"
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -54,6 +56,6 @@
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/app/src/app/(uncorked)/_uc/about/page.tsx
+++ b/app/src/app/(uncorked)/_uc/about/page.tsx
@@ -1,0 +1,141 @@
+import type { Metadata } from "next";
+import { Wine, Heart, Users, Trophy } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "About | Fullerton Uncorked 2026",
+  description:
+    "Learn about Fullerton Uncorked — its history, mission, and the Rotary Club of Fullerton behind it.",
+};
+
+const STATS = [
+  { value: "10+", label: "Years of Events" },
+  { value: "$500K+", label: "Raised for Community" },
+  { value: "400+", label: "Guests Each Year" },
+  { value: "50+", label: "Wineries & Vendors" },
+];
+
+const TIMELINE = [
+  { year: "2013", title: "The First Cork is Pulled", desc: "Fullerton Uncorked launches as a small community wine tasting, raising funds for Rotary youth programs." },
+  { year: "2016", title: "Moving to the YMCA", desc: "The event grows and finds its home at the Fullerton Family YMCA — perfect for an elegant evening in the heart of the city." },
+  { year: "2019", title: "Record Attendance", desc: "Over 500 guests attend, with 60+ vendors and a live auction raising a record amount for local nonprofits." },
+  { year: "2022", title: "Post-Pandemic Comeback", desc: "After a two-year hiatus, Fullerton Uncorked returns stronger than ever with renewed community energy." },
+  { year: "2026", title: "The Next Chapter", desc: "Join us October 17, 2026 for our most spectacular evening yet." },
+];
+
+export default function AboutPage() {
+  return (
+    <div className="bg-cream-50">
+      <section className="relative bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800 py-24 overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-16 -left-16 w-72 h-72 rounded-full bg-gold-500/10 blur-3xl" />
+          <div className="absolute -bottom-20 right-0 w-96 h-96 rounded-full bg-wine-600/20 blur-3xl" />
+        </div>
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gold-500/15 border border-gold-500/30 text-gold-400 text-xs font-semibold tracking-widest uppercase mb-5">
+            <Heart className="w-3.5 h-3.5" />
+            Our Story
+          </div>
+          <h1 className="text-5xl font-bold text-white mb-5 tracking-tight">About Fullerton Uncorked</h1>
+          <p className="text-xl text-wine-200 leading-relaxed max-w-2xl mx-auto">
+            A beloved Fullerton tradition bringing community, fine wine, and purpose together every fall.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-14 bg-white border-b border-wine-100">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-6 text-center">
+            {STATS.map(({ value, label }) => (
+              <div key={label} className="rounded-2xl border border-wine-100 bg-cream-50 p-6">
+                <div className="text-4xl font-bold text-wine-800 mb-1">{value}</div>
+                <div className="text-sm text-gray-500 font-medium">{label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20 sm:py-24">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-2 gap-14 items-start">
+            <div>
+              <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-wine-100 border border-wine-200 text-wine-700 text-xs font-semibold tracking-widest uppercase mb-5">
+                <Wine className="w-3.5 h-3.5" />
+                The Mission
+              </div>
+              <h2 className="text-3xl font-bold text-wine-950 mb-5">Wine That Does Good</h2>
+              <p className="text-gray-600 leading-relaxed mb-4">
+                Fullerton Uncorked was born from a simple idea: bring people together over great wine and use that connection to make Fullerton a better place. Every ticket sold, every bottle poured, every bid placed at the auction goes toward Rotary&apos;s mission of service above self.
+              </p>
+              <p className="text-gray-600 leading-relaxed">
+                When you raise a glass at Fullerton Uncorked, you&apos;re raising up your community.
+              </p>
+            </div>
+            <div className="space-y-4">
+              {[
+                { icon: Users, title: "Community First", desc: "Built by Rotarians, for the entire Fullerton community. Everyone is welcome at our table." },
+                { icon: Trophy, title: "Local Impact", desc: "Funds raised stay local — supporting schools, nonprofits, and youth programs in Orange County." },
+                { icon: Heart, title: "Service Above Self", desc: "The Rotary Club of Fullerton has served the community since 1922. This event is our signature celebration of that legacy." },
+              ].map(({ icon: Icon, title, desc }) => (
+                <div key={title} className="flex gap-4 rounded-2xl border border-wine-100 bg-white p-5 hover:border-wine-300 transition-all">
+                  <div className="w-11 h-11 rounded-xl bg-gradient-to-br from-wine-700 to-wine-950 flex items-center justify-center flex-shrink-0 shadow-md">
+                    <Icon className="w-5 h-5 text-gold-400" />
+                  </div>
+                  <div>
+                    <h3 className="font-bold text-wine-950 mb-1">{title}</h3>
+                    <p className="text-gray-500 text-sm leading-relaxed">{desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20 bg-white border-t border-wine-100">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-14">
+            <h2 className="text-3xl font-bold text-wine-950 mb-3">Our History</h2>
+            <p className="text-gray-500">A decade of pouring purpose into the community.</p>
+          </div>
+          <div className="relative">
+            <div className="absolute left-7 top-0 bottom-0 w-0.5 bg-wine-100" />
+            <div className="space-y-8">
+              {TIMELINE.map(({ year, title, desc }) => (
+                <div key={year} className="relative flex gap-6">
+                  <div className="relative z-10 flex-shrink-0 w-14 h-14 rounded-full bg-gradient-to-br from-wine-700 to-wine-950 flex items-center justify-center shadow-lg">
+                    <span className="text-xs font-bold text-gold-400">{year}</span>
+                  </div>
+                  <div className="flex-1 pt-3">
+                    <h3 className="font-bold text-wine-950 mb-1">{title}</h3>
+                    <p className="text-gray-500 text-sm leading-relaxed">{desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <div className="w-16 h-16 rounded-2xl bg-gold-500/20 border border-gold-500/30 flex items-center justify-center mx-auto mb-5">
+            <Wine className="w-7 h-7 text-gold-400" />
+          </div>
+          <h2 className="text-3xl font-bold text-white mb-4">The Rotary Club of Fullerton</h2>
+          <p className="text-wine-200 leading-relaxed mb-4 max-w-xl mx-auto">
+            Founded in 1922, the Rotary Club of Fullerton is one of Orange County&apos;s oldest and most active community service organizations.
+          </p>
+          <a
+            href="https://rotaryfullerton.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-gold-400 text-sm font-semibold hover:text-gold-300"
+          >
+            Learn more about Rotary Fullerton &rarr;
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/app/(uncorked)/_uc/contact/contact-form.tsx
+++ b/app/src/app/(uncorked)/_uc/contact/contact-form.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { Send, CheckCircle } from "lucide-react";
+
+export function ContactForm() {
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setStatus("submitting");
+    setError(null);
+
+    const formData = new FormData(e.currentTarget);
+    const body = {
+      name: formData.get("name") as string,
+      email: formData.get("email") as string,
+      subject: formData.get("subject") as string,
+      message: formData.get("message") as string,
+    };
+
+    try {
+      const res = await fetch("/api/public/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error("Failed to send");
+      setStatus("success");
+    } catch {
+      setStatus("error");
+      setError("Something went wrong. Please email us directly at info@fullertonuncorked.org");
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div className="text-center py-12">
+        <div className="w-16 h-16 rounded-2xl bg-green-100 flex items-center justify-center mx-auto mb-4">
+          <CheckCircle className="w-8 h-8 text-green-600" />
+        </div>
+        <h3 className="text-xl font-bold text-wine-950 mb-2">Message Sent!</h3>
+        <p className="text-gray-500 text-sm">Thank you for reaching out. We&apos;ll get back to you within 1-2 business days.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div className="grid sm:grid-cols-2 gap-5">
+        <div>
+          <label htmlFor="contact-name" className="block text-sm font-semibold text-wine-900 mb-1.5">Name</label>
+          <input
+            id="contact-name"
+            name="name"
+            type="text"
+            required
+            placeholder="Your full name"
+            className="w-full px-4 py-3 rounded-xl border border-gray-200 text-sm focus:outline-none focus:border-wine-400 focus:ring-2 focus:ring-wine-400/20 transition-all"
+          />
+        </div>
+        <div>
+          <label htmlFor="contact-email" className="block text-sm font-semibold text-wine-900 mb-1.5">Email</label>
+          <input
+            id="contact-email"
+            name="email"
+            type="email"
+            required
+            placeholder="you@example.com"
+            className="w-full px-4 py-3 rounded-xl border border-gray-200 text-sm focus:outline-none focus:border-wine-400 focus:ring-2 focus:ring-wine-400/20 transition-all"
+          />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="contact-subject" className="block text-sm font-semibold text-wine-900 mb-1.5">Subject</label>
+        <select
+          id="contact-subject"
+          name="subject"
+          required
+          className="w-full px-4 py-3 rounded-xl border border-gray-200 text-sm focus:outline-none focus:border-wine-400 focus:ring-2 focus:ring-wine-400/20 transition-all bg-white"
+        >
+          <option value="">Select a topic...</option>
+          <option value="tickets">Ticket Questions</option>
+          <option value="sponsorship">Sponsorship Inquiry</option>
+          <option value="vendor">Vendor / Exhibitor</option>
+          <option value="volunteering">Volunteering</option>
+          <option value="media">Media / Press</option>
+          <option value="general">General Question</option>
+        </select>
+      </div>
+      <div>
+        <label htmlFor="contact-message" className="block text-sm font-semibold text-wine-900 mb-1.5">Message</label>
+        <textarea
+          id="contact-message"
+          name="message"
+          required
+          rows={5}
+          placeholder="Tell us how we can help..."
+          className="w-full px-4 py-3 rounded-xl border border-gray-200 text-sm focus:outline-none focus:border-wine-400 focus:ring-2 focus:ring-wine-400/20 transition-all resize-none"
+        />
+      </div>
+      {error && (
+        <p className="text-red-600 text-sm bg-red-50 rounded-xl px-4 py-3">{error}</p>
+      )}
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl bg-gradient-to-r from-wine-700 to-wine-900 text-white font-bold text-sm shadow-lg hover:from-wine-600 hover:to-wine-800 transition-all disabled:opacity-60"
+      >
+        <Send className="w-4 h-4" />
+        {status === "submitting" ? "Sending..." : "Send Message"}
+      </button>
+    </form>
+  );
+}

--- a/app/src/app/(uncorked)/_uc/contact/page.tsx
+++ b/app/src/app/(uncorked)/_uc/contact/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import { Wine, Mail, MapPin, Send } from "lucide-react";
+import { ContactForm } from "./contact-form";
+
+export const metadata: Metadata = {
+  title: "Contact | Fullerton Uncorked 2026",
+  description:
+    "Get in touch with the Fullerton Uncorked team.",
+};
+
+export default function ContactPage() {
+  return (
+    <div className="bg-cream-50">
+      <section className="relative bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800 py-24 overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-16 -left-16 w-72 h-72 rounded-full bg-gold-500/10 blur-3xl" />
+          <div className="absolute -bottom-20 right-0 w-80 h-80 rounded-full bg-wine-600/20 blur-3xl" />
+        </div>
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gold-500/15 border border-gold-500/30 text-gold-400 text-xs font-semibold tracking-widest uppercase mb-5">
+            <Mail className="w-3.5 h-3.5" />
+            Get In Touch
+          </div>
+          <h1 className="text-5xl font-bold text-white mb-5 tracking-tight">Contact Us</h1>
+          <p className="text-xl text-wine-200 leading-relaxed max-w-2xl mx-auto">
+            Questions, sponsorships, vendor inquiries &mdash; we&apos;d love to hear from you.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-20 sm:py-24">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid lg:grid-cols-5 gap-12">
+            <div className="lg:col-span-2 space-y-6">
+              <div>
+                <h2 className="text-xl font-bold text-wine-950 mb-4">Get In Touch</h2>
+                <p className="text-gray-500 text-sm leading-relaxed">
+                  Our team is happy to answer questions about tickets, sponsorships, vendor opportunities, or anything else about Fullerton Uncorked.
+                </p>
+              </div>
+              <div className="space-y-4">
+                <div className="flex gap-3 items-start">
+                  <div className="w-9 h-9 rounded-xl bg-wine-100 flex items-center justify-center flex-shrink-0">
+                    <Mail className="w-4 h-4 text-wine-700" />
+                  </div>
+                  <div>
+                    <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1">Email</div>
+                    <a href="mailto:info@fullertonuncorked.org" className="text-wine-700 text-sm font-medium hover:text-wine-500">
+                      info@fullertonuncorked.org
+                    </a>
+                  </div>
+                </div>
+                <div className="flex gap-3 items-start">
+                  <div className="w-9 h-9 rounded-xl bg-wine-100 flex items-center justify-center flex-shrink-0">
+                    <MapPin className="w-4 h-4 text-wine-700" />
+                  </div>
+                  <div>
+                    <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1">Event Venue</div>
+                    <address className="text-sm text-gray-600 not-italic leading-relaxed">
+                      Fullerton Family YMCA<br />
+                      400 W. Commonwealth Ave<br />
+                      Fullerton, CA 92832
+                    </address>
+                  </div>
+                </div>
+                <div className="flex gap-3 items-start">
+                  <div className="w-9 h-9 rounded-xl bg-wine-100 flex items-center justify-center flex-shrink-0">
+                    <Wine className="w-4 h-4 text-wine-700" />
+                  </div>
+                  <div>
+                    <div className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-1">Event Date</div>
+                    <div className="text-sm text-gray-600">Saturday, October 17, 2026<br />6:00 PM – 10:00 PM</div>
+                  </div>
+                </div>
+              </div>
+              <div className="rounded-2xl border border-gold-200 bg-gold-50 p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <Send className="w-4 h-4 text-gold-600" />
+                  <span className="text-sm font-bold text-gold-800">Sponsorship Inquiries</span>
+                </div>
+                <p className="text-xs text-gold-700 leading-relaxed">
+                  Email us at{" "}
+                  <a href="mailto:sponsor@fullertonuncorked.org" className="font-semibold underline">
+                    sponsor@fullertonuncorked.org
+                  </a>{" "}
+                  for our 2026 sponsorship prospectus.
+                </p>
+              </div>
+            </div>
+            <div className="lg:col-span-3">
+              <div className="rounded-2xl border border-wine-100 bg-white p-8 shadow-sm">
+                <h2 className="text-xl font-bold text-wine-950 mb-6">Send Us a Message</h2>
+                <ContactForm />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/app/(uncorked)/_uc/faq/page.tsx
+++ b/app/src/app/(uncorked)/_uc/faq/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import { Wine, HelpCircle } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "FAQ | Fullerton Uncorked 2026",
+  description:
+    "Frequently asked questions about Fullerton Uncorked 2026 — parking, age requirements, rain policy, refunds, and more.",
+};
+
+const FAQS = [
+  {
+    category: "General",
+    items: [
+      { q: "What is Fullerton Uncorked?", a: "Fullerton Uncorked is an annual wine and beer tasting event benefiting the Rotary Club of Fullerton Foundation. Guests enjoy premium wines, craft beers, gourmet food, live entertainment, and a silent auction — all in support of local community programs." },
+      { q: "When and where is the 2026 event?", a: "Saturday, October 17, 2026 at the Fullerton Family YMCA, 400 W. Commonwealth Ave, Fullerton, CA 92832. Doors open at 6:00 PM (VIP at 5:30 PM)." },
+      { q: "Is this event 21+?", a: "Yes. Fullerton Uncorked is a 21+ event. Valid government-issued photo ID is required at check-in for all guests. No exceptions." },
+    ],
+  },
+  {
+    category: "Tickets",
+    items: [
+      { q: "How do I purchase tickets?", a: "Tickets are available online through our ticketing partner. Visit our Tickets page to purchase General Admission, VIP, or Designated Driver tickets." },
+      { q: "What is the refund policy?", a: "All ticket sales are final and non-refundable. However, tickets may be transferred to another person. Please contact us at info@fullertonuncorked.org if you need to transfer your ticket." },
+      { q: "What is included with my ticket?", a: "General Admission includes a tasting glass and unlimited wine and beer tastings throughout the evening. VIP includes early entry at 5:30 PM, a welcome glass, and access to the VIP lounge. Designated Driver tickets include admission and non-alcoholic beverages." },
+    ],
+  },
+  {
+    category: "Parking & Getting Here",
+    items: [
+      { q: "Where should I park?", a: "Free parking is available in the YMCA parking lot and on adjacent streets. We encourage carpooling or rideshare services. Please plan ahead — parking fills quickly." },
+      { q: "Is the venue accessible?", a: "Yes, the Fullerton Family YMCA is fully ADA accessible. If you have specific accessibility needs, please contact us in advance at info@fullertonuncorked.org." },
+    ],
+  },
+  {
+    category: "Rain & Event Policy",
+    items: [
+      { q: "What happens if it rains?", a: "Fullerton Uncorked is held rain or shine. The event takes place in covered and indoor spaces at the YMCA. In the unlikely event of cancellation due to severe weather, ticket holders will be notified and refunds processed." },
+      { q: "Can I bring outside food or beverages?", a: "Outside food and beverages are not permitted. The event features a wide selection of wines, craft beers, and food sampling from our vendors." },
+      { q: "Is the event pet-friendly?", a: "Only ADA-certified service animals are permitted at the event." },
+    ],
+  },
+];
+
+export default function FAQPage() {
+  return (
+    <div className="bg-cream-50">
+      <section className="relative bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800 py-24 overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-16 -left-16 w-72 h-72 rounded-full bg-gold-500/10 blur-3xl" />
+          <div className="absolute -bottom-20 right-0 w-80 h-80 rounded-full bg-wine-600/20 blur-3xl" />
+        </div>
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gold-500/15 border border-gold-500/30 text-gold-400 text-xs font-semibold tracking-widest uppercase mb-5">
+            <HelpCircle className="w-3.5 h-3.5" />
+            Need Help?
+          </div>
+          <h1 className="text-5xl font-bold text-white mb-5 tracking-tight">FAQ</h1>
+          <p className="text-xl text-wine-200 leading-relaxed max-w-2xl mx-auto">
+            Everything you need to know before you arrive.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-20 sm:py-24">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 space-y-12">
+          {FAQS.map(({ category, items }) => (
+            <div key={category}>
+              <div className="flex items-center gap-3 mb-6">
+                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-wine-700 to-wine-950 flex items-center justify-center">
+                  <Wine className="w-4 h-4 text-gold-400" />
+                </div>
+                <h2 className="text-xl font-bold text-wine-950">{category}</h2>
+              </div>
+              <div className="space-y-4">
+                {items.map(({ q, a }) => (
+                  <div key={q} className="rounded-2xl border border-wine-100 bg-white p-6 hover:border-wine-200 transition-all">
+                    <h3 className="font-bold text-wine-900 mb-3">{q}</h3>
+                    <p className="text-gray-500 text-sm leading-relaxed">{a}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="py-12 bg-white border-t border-wine-100">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <HelpCircle className="w-8 h-8 text-wine-400 mx-auto mb-4" />
+          <h3 className="text-lg font-bold text-wine-950 mb-2">Still Have Questions?</h3>
+          <p className="text-gray-500 text-sm mb-4">
+            We&apos;re happy to help. Reach out and we&apos;ll get back to you promptly.
+          </p>
+          <a href="/contact" className="text-wine-700 text-sm font-semibold hover:text-wine-500 underline underline-offset-2">
+            Contact us &rarr;
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/app/(uncorked)/_uc/gallery/page.tsx
+++ b/app/src/app/(uncorked)/_uc/gallery/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import { Wine, Camera, ImageIcon } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Gallery | Fullerton Uncorked 2026",
+  description:
+    "Photos from past Fullerton Uncorked events.",
+};
+
+const GALLERY_YEARS = [
+  { year: "2023", images: 6 },
+  { year: "2022", images: 6 },
+  { year: "2019", images: 4 },
+];
+
+const COLORS = [
+  "bg-wine-900", "bg-wine-800", "bg-wine-700",
+  "bg-wine-600", "bg-gold-700", "bg-gold-600",
+];
+
+export default function GalleryPage() {
+  return (
+    <div className="bg-cream-50">
+      <section className="relative bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800 py-24 overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-16 -left-16 w-72 h-72 rounded-full bg-gold-500/10 blur-3xl" />
+          <div className="absolute -bottom-20 right-0 w-80 h-80 rounded-full bg-wine-600/20 blur-3xl" />
+        </div>
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gold-500/15 border border-gold-500/30 text-gold-400 text-xs font-semibold tracking-widest uppercase mb-5">
+            <Camera className="w-3.5 h-3.5" />
+            Past Events
+          </div>
+          <h1 className="text-5xl font-bold text-white mb-5 tracking-tight">Event Gallery</h1>
+          <p className="text-xl text-wine-200 leading-relaxed max-w-2xl mx-auto">
+            A glimpse into the elegance, community, and joy of Fullerton Uncorked.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-20 sm:py-24">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 space-y-16">
+          {GALLERY_YEARS.map(({ year, images }) => (
+            <div key={year}>
+              <div className="flex items-center gap-4 mb-8">
+                <div className="flex items-center gap-2">
+                  <Wine className="w-4 h-4 text-wine-500" />
+                  <h2 className="text-2xl font-bold text-wine-950">Fullerton Uncorked {year}</h2>
+                </div>
+                <div className="flex-1 h-px bg-wine-100" />
+              </div>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4">
+                {Array.from({ length: images }).map((_, i) => (
+                  <div
+                    key={i}
+                    className={`relative rounded-2xl overflow-hidden aspect-[4/3] ${COLORS[i % COLORS.length]} flex items-center justify-center group hover:scale-[1.02] transition-transform cursor-pointer shadow-md`}
+                  >
+                    <div className="absolute inset-0 bg-gradient-to-br from-black/10 to-black/40" />
+                    <div className="relative text-center">
+                      <ImageIcon className="w-8 h-8 text-white/40 mx-auto mb-2" />
+                      <span className="text-white/40 text-xs font-medium">{year} Photo {i + 1}</span>
+                    </div>
+                    <div className="absolute inset-0 opacity-0 group-hover:opacity-100 bg-wine-950/20 transition-opacity flex items-center justify-center">
+                      <Camera className="w-6 h-6 text-white" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="py-12 bg-white border-t border-wine-100">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <Camera className="w-8 h-8 text-wine-400 mx-auto mb-4" />
+          <h3 className="text-lg font-bold text-wine-950 mb-2">Be Part of the Story</h3>
+          <p className="text-gray-500 text-sm">
+            Photos from Fullerton Uncorked 2026 will appear here after the event. Tag us with <span className="font-semibold text-wine-700">#FullertonUncorked</span>.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/app/(uncorked)/_uc/page.tsx
+++ b/app/src/app/(uncorked)/_uc/page.tsx
@@ -1,0 +1,183 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Wine, Calendar, MapPin, Ticket, ChevronRight, Star, Heart, Music, Utensils } from "lucide-react";
+import { getEventConfig } from "@/lib/queries/event-config";
+import { getPublicContacts } from "@/lib/queries/contacts";
+import type { Contact } from "@/lib/types";
+
+export const metadata: Metadata = {
+  title: "Fullerton Uncorked 2026 — Fine Wine, Craft Beer & Culinary Excellence",
+  description:
+    "Join us October 17, 2026 for Fullerton Uncorked — an elegant evening of wine, craft beer, and culinary excellence benefiting the Rotary Club of Fullerton.",
+  openGraph: {
+    title: "Fullerton Uncorked 2026",
+    description: "An evening of fine wine, craft beer, and culinary excellence benefiting Rotary.",
+    url: "https://fullertonuncorked.org",
+    siteName: "Fullerton Uncorked",
+    type: "website",
+  },
+};
+
+const HIGHLIGHTS = [
+  { icon: Wine, label: "Premium Wines", desc: "Curated selections from California's finest vineyards" },
+  { icon: Utensils, label: "Culinary Excellence", desc: "Gourmet bites from top local restaurants & chefs" },
+  { icon: Music, label: "Live Entertainment", desc: "Jazz, acoustic performances & silent auction" },
+  { icon: Heart, label: "Community Impact", desc: "100% of proceeds benefit local Rotary programs" },
+];
+
+export default async function HomePage() {
+  let ticketUrl: string | undefined;
+  let sponsors: Contact[] = [];
+
+  try {
+    const config = await getEventConfig();
+    ticketUrl = config.ticketUrlGeneral || undefined;
+  } catch { /* DB not configured */ }
+
+  try {
+    sponsors = await getPublicContacts(["sponsor"]);
+  } catch { /* DB not configured */ }
+
+  const featuredSponsors = sponsors.filter(
+    (s) => s.tier === "title" || s.tier === "platinum" || s.tier === "gold"
+  );
+
+  return (
+    <div className="bg-cream-50">
+      {/* Hero */}
+      <section className="relative min-h-[92vh] flex items-center justify-center bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800 overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-24 -left-24 w-96 h-96 rounded-full bg-gold-500/10 blur-3xl" />
+          <div className="absolute top-1/2 right-0 w-80 h-80 rounded-full bg-wine-600/25 blur-3xl" />
+        </div>
+        <div className="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center py-24">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gold-500/15 border border-gold-500/30 text-gold-400 text-xs font-semibold tracking-widest uppercase mb-8">
+            <Wine className="w-3.5 h-3.5" />
+            October 17, 2026
+          </div>
+          <h1 className="text-5xl sm:text-7xl font-bold text-white mb-6 tracking-tight leading-none">
+            Fullerton<br />
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-gold-300 to-gold-500">Uncorked</span>
+          </h1>
+          <p className="text-xl sm:text-2xl text-wine-200 mb-4 font-light max-w-2xl mx-auto">
+            An elegant evening of fine wine, craft beer &amp; culinary excellence
+          </p>
+          <div className="flex items-center justify-center gap-2 text-wine-300 text-sm mb-10">
+            <MapPin className="w-4 h-4 text-gold-400" />
+            Fullerton Family YMCA &middot; Fullerton, CA
+          </div>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            {ticketUrl ? (
+              <a
+                href={ticketUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-gold-400 to-gold-600 text-wine-950 font-bold text-lg shadow-2xl hover:from-gold-300 hover:to-gold-500 transition-all hover:-translate-y-0.5"
+              >
+                <Ticket className="w-5 h-5" />
+                Get Tickets
+              </a>
+            ) : (
+              <Link
+                href="/tickets"
+                className="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-gold-400 to-gold-600 text-wine-950 font-bold text-lg shadow-2xl hover:from-gold-300 hover:to-gold-500 transition-all hover:-translate-y-0.5"
+              >
+                <Ticket className="w-5 h-5" />
+                Get Tickets
+              </Link>
+            )}
+            <Link
+              href="/about"
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-xl border border-wine-500/50 text-wine-100 font-semibold text-lg hover:bg-wine-800/40 transition-all"
+            >
+              Learn More
+              <ChevronRight className="w-5 h-5" />
+            </Link>
+          </div>
+        </div>
+        <div className="absolute bottom-0 inset-x-0 bg-wine-950/80 backdrop-blur-sm border-t border-wine-700/50 py-5">
+          <div className="max-w-3xl mx-auto px-4 flex items-center justify-center gap-2">
+            <Calendar className="w-4 h-4 text-gold-400 flex-shrink-0" />
+            <span className="text-wine-300 text-sm">
+              <span className="text-gold-400 font-bold">Save the Date:</span> Saturday, October 17, 2026 &middot; 6:00 PM &ndash; 10:00 PM
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Highlights */}
+      <section className="py-20 sm:py-24 bg-white">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-14">
+            <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-wine-100 border border-wine-200 text-wine-700 text-xs font-semibold tracking-widest uppercase mb-4">
+              <Star className="w-3.5 h-3.5" />
+              The Experience
+            </div>
+            <h2 className="text-4xl font-bold text-wine-950 mb-3">An Evening to Remember</h2>
+            <p className="text-gray-500 text-lg max-w-xl mx-auto">
+              Fullerton Uncorked brings together the finest wines, food, and community spirit for a night of celebration.
+            </p>
+          </div>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {HIGHLIGHTS.map(({ icon: Icon, label, desc }) => (
+              <div key={label} className="group rounded-2xl border border-wine-100 bg-cream-50 p-6 text-center hover:border-wine-300 hover:shadow-lg transition-all">
+                <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-wine-700 to-wine-950 flex items-center justify-center mx-auto mb-4 shadow-lg group-hover:scale-105 transition-transform">
+                  <Icon className="w-6 h-6 text-gold-400" />
+                </div>
+                <h3 className="text-lg font-bold text-wine-950 mb-2">{label}</h3>
+                <p className="text-gray-500 text-sm leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Sponsors preview */}
+      {featuredSponsors.length > 0 && (
+        <section className="py-16 bg-cream-50 border-t border-wine-100">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <p className="text-xs font-bold uppercase tracking-widest text-gray-400 mb-8">Proudly Supported By</p>
+            <div className="flex flex-wrap items-center justify-center gap-4 mb-8">
+              {featuredSponsors.map((s) => (
+                <div key={s.id} className="inline-flex items-center justify-center h-14 min-w-[120px] px-5 rounded-xl bg-white border border-gray-200 shadow-sm">
+                  {s.logoUrl
+                    // eslint-disable-next-line @next/next/no-img-element
+                    ? <img src={s.logoUrl} alt={s.name} className="max-h-full max-w-full object-contain" />
+                    : <span className="text-sm font-semibold text-gray-700">{s.name}</span>}
+                </div>
+              ))}
+            </div>
+            <Link href="/sponsors" className="text-wine-700 text-sm font-semibold hover:text-wine-500 underline underline-offset-2">
+              View all sponsors &rarr;
+            </Link>
+          </div>
+        </section>
+      )}
+
+      {/* CTA */}
+      <section className="py-20 bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <h2 className="text-4xl font-bold text-white mb-4">Ready to Join Us?</h2>
+          <p className="text-wine-200 text-lg mb-8 max-w-xl mx-auto">
+            Tickets sell fast. Secure yours today and join hundreds of wine lovers supporting the Fullerton community.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/tickets"
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gradient-to-r from-gold-400 to-gold-600 text-wine-950 font-bold text-lg shadow-xl hover:from-gold-300 hover:to-gold-500 transition-all"
+            >
+              <Ticket className="w-5 h-5" />
+              Purchase Tickets
+            </Link>
+            <Link
+              href="/contact"
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-xl border border-wine-500/50 text-wine-100 font-semibold text-lg hover:bg-wine-800/40 transition-all"
+            >
+              Contact Us
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/app/(uncorked)/_uc/schedule/page.tsx
+++ b/app/src/app/(uncorked)/_uc/schedule/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import { Clock, Wine, Music, Gavel, Ticket } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Schedule | Fullerton Uncorked 2026",
+  description:
+    "View the full schedule for Fullerton Uncorked 2026 — Saturday, October 17 at the Fullerton Family YMCA.",
+};
+
+const SCHEDULE = [
+  { time: "5:30 PM", title: "VIP Early Entry", desc: "VIP ticket holders get early access, a welcome glass of wine, and first choice at the silent auction.", icon: Ticket, highlight: true },
+  { time: "6:00 PM", title: "General Admission Opens", desc: "Doors open for all guests. Pick up your tasting glass and start exploring the wine and beer vendors.", icon: Wine, highlight: false },
+  { time: "6:00–9:00 PM", title: "Wine & Beer Tastings", desc: "Sample from 30+ wineries and craft breweries. Stroll through vendor booths and enjoy gourmet bites.", icon: Wine, highlight: false },
+  { time: "6:30 PM", title: "Live Entertainment Begins", desc: "Enjoy live jazz and acoustic performances throughout the evening.", icon: Music, highlight: false },
+  { time: "7:00 PM", title: "Silent Auction Opens", desc: "Bid on exclusive wine packages, getaways, restaurant experiences, and more.", icon: Gavel, highlight: false },
+  { time: "8:30 PM", title: "Last Call for Auction Bids", desc: "Final opportunity to place bids on your favorite auction items before they close.", icon: Gavel, highlight: false },
+  { time: "8:45 PM", title: "Raffle Drawing", desc: "Raffle tickets available throughout the evening. Must be present to win some prizes.", icon: Ticket, highlight: false },
+  { time: "9:00 PM", title: "Silent Auction Closes", desc: "Winning bidders notified and items claimed.", icon: Gavel, highlight: false },
+  { time: "9:30 PM", title: "Last Pour", desc: "Final wine and beer pours of the evening.", icon: Wine, highlight: false },
+  { time: "10:00 PM", title: "Event Concludes", desc: "Safe travels home — thank you for supporting Rotary Fullerton!", icon: Clock, highlight: false },
+];
+
+export default function SchedulePage() {
+  return (
+    <div className="bg-cream-50">
+      <section className="relative bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800 py-24 overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-16 -left-16 w-72 h-72 rounded-full bg-gold-500/10 blur-3xl" />
+          <div className="absolute -bottom-20 right-0 w-80 h-80 rounded-full bg-wine-600/20 blur-3xl" />
+        </div>
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gold-500/15 border border-gold-500/30 text-gold-400 text-xs font-semibold tracking-widest uppercase mb-5">
+            <Clock className="w-3.5 h-3.5" />
+            October 17, 2026
+          </div>
+          <h1 className="text-5xl font-bold text-white mb-5 tracking-tight">Event Schedule</h1>
+          <p className="text-xl text-wine-200 leading-relaxed max-w-2xl mx-auto">
+            An evening carefully crafted for great wine, great food, and great company.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-20 sm:py-24">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="relative">
+            <div className="absolute left-5 top-0 bottom-0 w-0.5 bg-wine-100 sm:left-6" />
+            <div className="space-y-6">
+              {SCHEDULE.map(({ time, title, desc, icon: Icon, highlight }) => (
+                <div key={time} className="relative flex gap-5 sm:gap-6">
+                  <div className={`relative z-10 flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center shadow-lg ${highlight ? "bg-gradient-to-br from-gold-400 to-gold-600" : "bg-gradient-to-br from-wine-700 to-wine-950"}`}>
+                    <Icon className={`w-4 h-4 sm:w-5 sm:h-5 ${highlight ? "text-wine-950" : "text-gold-400"}`} />
+                  </div>
+                  <div className={`flex-1 rounded-2xl border p-5 transition-all ${highlight ? "border-gold-300 bg-gradient-to-r from-gold-50 to-cream-50 shadow-md" : "border-wine-100 bg-white hover:border-wine-200"}`}>
+                    <div className="flex flex-wrap items-start justify-between gap-2 mb-2">
+                      <h3 className={`font-bold text-base ${highlight ? "text-wine-950" : "text-wine-900"}`}>{title}</h3>
+                      <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${highlight ? "bg-gold-200 text-gold-800" : "bg-wine-100 text-wine-700"}`}>{time}</span>
+                    </div>
+                    <p className="text-gray-500 text-sm leading-relaxed">{desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-wine-50 border-t border-wine-100">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="rounded-2xl border border-wine-200 bg-white p-6 text-center">
+            <p className="text-sm text-gray-500">
+              <span className="font-semibold text-wine-900">Schedule subject to change.</span> Final timings will be confirmed closer to the event.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/app/(uncorked)/_uc/tickets/page.tsx
+++ b/app/src/app/(uncorked)/_uc/tickets/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from "next";
+import { Wine, Ticket, Star, CheckCircle, ExternalLink } from "lucide-react";
+import { getEventConfig } from "@/lib/queries/event-config";
+import type { EventConfig } from "@/lib/queries/event-config";
+
+export const metadata: Metadata = {
+  title: "Tickets | Fullerton Uncorked 2026",
+  description:
+    "Purchase tickets for Fullerton Uncorked 2026 — General Admission, VIP, and Designated Driver options available.",
+};
+
+type TierDef = {
+  name: string;
+  price: string;
+  badge: string | null;
+  color: string;
+  btnColor: string;
+  includes: string[];
+  urlKey: keyof EventConfig | null;
+};
+
+const TIERS: TierDef[] = [
+  {
+    name: "Designated Driver",
+    price: "$20",
+    badge: null,
+    color: "border-gray-200 bg-white",
+    btnColor: "bg-gray-800 hover:bg-gray-700 text-white",
+    includes: [
+      "Event admission",
+      "Non-alcoholic beverages",
+      "Food sampling",
+      "Access to silent auction & raffle",
+    ],
+    urlKey: null,
+  },
+  {
+    name: "General Admission",
+    price: "$75",
+    badge: "Most Popular",
+    color: "border-wine-300 bg-white",
+    btnColor: "bg-gradient-to-r from-wine-700 to-wine-900 hover:from-wine-600 hover:to-wine-800 text-white",
+    includes: [
+      "Tasting glass",
+      "Unlimited wine & beer tastings",
+      "Gourmet food sampling",
+      "Live entertainment",
+      "Silent auction & raffle access",
+    ],
+    urlKey: "ticketUrlGeneral",
+  },
+  {
+    name: "VIP",
+    price: "$125",
+    badge: "Best Experience",
+    color: "border-gold-400 bg-gradient-to-b from-gold-50 to-white shadow-xl shadow-gold-900/10",
+    btnColor: "bg-gradient-to-r from-gold-400 to-gold-600 hover:from-gold-300 hover:to-gold-500 text-wine-950",
+    includes: [
+      "Early entry at 5:30 PM",
+      "Welcome glass of premium wine",
+      "Tasting glass",
+      "Unlimited wine & beer tastings",
+      "Gourmet food sampling",
+      "Live entertainment",
+      "Priority auction bidding",
+      "Exclusive VIP lounge access",
+    ],
+    urlKey: "ticketUrlVip",
+  },
+];
+
+export default async function TicketsPage() {
+  let config: EventConfig | null = null;
+  try {
+    config = await getEventConfig();
+  } catch { /* DB not configured */ }
+
+  return (
+    <div className="bg-cream-50">
+      <section className="relative bg-gradient-to-br from-wine-950 via-wine-900 to-wine-800 py-24 overflow-hidden">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute -top-16 -left-16 w-72 h-72 rounded-full bg-gold-500/10 blur-3xl" />
+          <div className="absolute -bottom-20 right-0 w-80 h-80 rounded-full bg-wine-600/20 blur-3xl" />
+        </div>
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gold-500/15 border border-gold-500/30 text-gold-400 text-xs font-semibold tracking-widest uppercase mb-5">
+            <Ticket className="w-3.5 h-3.5" />
+            Secure Your Spot
+          </div>
+          <h1 className="text-5xl font-bold text-white mb-5 tracking-tight">Tickets</h1>
+          <p className="text-xl text-wine-200 leading-relaxed max-w-2xl mx-auto">
+            Choose your experience for Fullerton Uncorked 2026 &mdash; Saturday, October 17.
+          </p>
+        </div>
+      </section>
+
+      <section className="py-20 sm:py-24">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid md:grid-cols-3 gap-6 lg:gap-8 items-start">
+            {TIERS.map(({ name, price, badge, color, btnColor, includes, urlKey }) => {
+              const url = urlKey && config ? (config[urlKey] as string | undefined) : undefined;
+              return (
+                <div key={name} className={`relative rounded-2xl border-2 p-8 flex flex-col ${color}`}>
+                  {badge && (
+                    <div className={`absolute -top-3.5 left-1/2 -translate-x-1/2 px-4 py-1 rounded-full text-xs font-bold tracking-wide whitespace-nowrap ${badge === "Best Experience" ? "bg-gradient-to-r from-gold-400 to-gold-600 text-wine-950" : "bg-wine-800 text-white"}`}>
+                      {badge}
+                    </div>
+                  )}
+                  <div className="mb-6">
+                    <div className="flex items-center gap-2 mb-1">
+                      {badge === "Best Experience" && <Star className="w-4 h-4 text-gold-500" />}
+                      <h2 className="text-xl font-bold text-wine-950">{name}</h2>
+                    </div>
+                    <div className="text-4xl font-bold text-wine-800 mt-2">{price}</div>
+                    <div className="text-xs text-gray-400 mt-1">per person</div>
+                  </div>
+                  <ul className="space-y-3 mb-8 flex-1">
+                    {includes.map((item) => (
+                      <li key={item} className="flex items-start gap-2.5">
+                        <CheckCircle className="w-4 h-4 text-wine-500 flex-shrink-0 mt-0.5" />
+                        <span className="text-sm text-gray-600">{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  {urlKey === null ? (
+                    <a
+                      href="/contact"
+                      className={`inline-flex items-center justify-center gap-2 w-full py-3.5 rounded-xl font-bold text-sm shadow-md transition-all ${btnColor}`}
+                    >
+                      <Ticket className="w-4 h-4" />
+                      Inquire for DD Tickets
+                    </a>
+                  ) : url ? (
+                    <a
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`inline-flex items-center justify-center gap-2 w-full py-3.5 rounded-xl font-bold text-sm shadow-md transition-all ${btnColor}`}
+                    >
+                      <Ticket className="w-4 h-4" />
+                      Buy {name} Tickets
+                      <ExternalLink className="w-3.5 h-3.5 opacity-70" />
+                    </a>
+                  ) : (
+                    <div className={`inline-flex items-center justify-center gap-2 w-full py-3.5 rounded-xl font-bold text-sm opacity-60 cursor-not-allowed ${btnColor}`}>
+                      <Ticket className="w-4 h-4" />
+                      Coming Soon
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-white border-t border-wine-100">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <Wine className="w-8 h-8 text-wine-400 mx-auto mb-4" />
+          <h3 className="text-lg font-bold text-wine-950 mb-2">Questions About Tickets?</h3>
+          <p className="text-gray-500 text-sm mb-4">
+            All ticket sales are final. Event is 21+ for alcohol consumption. Valid government-issued ID required at the door.
+          </p>
+          <a href="/contact" className="text-wine-700 text-sm font-semibold hover:text-wine-500 underline underline-offset-2">
+            Contact us with questions &rarr;
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/src/app/admin/board/meetings/page.tsx
+++ b/app/src/app/admin/board/meetings/page.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Calendar, Plus, X, ChevronDown, ChevronUp, Loader2, Trash2, Save } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type MeetingStatus = "scheduled" | "held" | "cancelled";
+
+interface BoardMeeting {
+  id: string;
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  agenda: string;
+  minutes: string;
+  attendees: string;
+  status: MeetingStatus;
+}
+
+const STATUS_STYLES: Record<MeetingStatus, string> = {
+  scheduled: "bg-blue-50 text-blue-700 border-blue-200",
+  held: "bg-green-50 text-green-700 border-green-200",
+  cancelled: "bg-red-50 text-red-700 border-red-200",
+};
+
+function parseAttendees(raw: string): string[] {
+  try { return JSON.parse(raw); } catch { return []; }
+}
+
+const EMPTY: typeof formDefaults = {
+  title: "", date: "", time: "", location: "", agenda: "", minutes: "", attendees: "", status: "scheduled",
+};
+
+const formDefaults = {
+  title: "", date: "", time: "", location: "", agenda: "", minutes: "", attendees: "",
+  status: "scheduled" as MeetingStatus,
+};
+
+export default function BoardMeetingsPage() {
+  const [meetings, setMeetings] = useState<BoardMeeting[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [form, setForm] = useState(formDefaults);
+
+  const fetch_ = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch("/api/board/meetings");
+    setMeetings(await res.json());
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetch_(); }, [fetch_]);
+
+  function openCreate() { setForm(formDefaults); setEditId(null); setShowForm(true); }
+  function openEdit(m: BoardMeeting) {
+    setForm({ title: m.title, date: m.date, time: m.time, location: m.location, agenda: m.agenda, minutes: m.minutes, attendees: parseAttendees(m.attendees).join(", "), status: m.status });
+    setEditId(m.id); setShowForm(true);
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault(); setSaving(true);
+    const payload = { ...form, attendees: JSON.stringify(form.attendees.split(",").map((s) => s.trim()).filter(Boolean)) };
+    if (editId) {
+      await fetch(`/api/board/meetings/${editId}`, { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+    } else {
+      await fetch("/api/board/meetings", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+    }
+    setSaving(false); setShowForm(false); fetch_();
+  }
+
+  async function del(id: string) {
+    if (!confirm("Delete this meeting?")) return;
+    await fetch(`/api/board/meetings/${id}`, { method: "DELETE" });
+    fetch_();
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2"><Calendar className="h-6 w-6 text-blue-600" /> Board Meetings</h1>
+          <p className="text-sm text-gray-500 mt-0.5">Schedule meetings, record agenda &amp; minutes, track attendees.</p>
+        </div>
+        <button onClick={openCreate} className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 transition-colors">
+          <Plus className="h-4 w-4" /> New Meeting
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="mb-6 rounded-xl border bg-white shadow-sm p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-semibold text-gray-900">{editId ? "Edit Meeting" : "New Meeting"}</h2>
+            <button onClick={() => setShowForm(false)}><X className="h-4 w-4 text-gray-400 hover:text-gray-600" /></button>
+          </div>
+          <form onSubmit={submit} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Title *</label>
+              <input required value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Status</label>
+              <select value={form.status} onChange={(e) => setForm({ ...form, status: e.target.value as MeetingStatus })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <option value="scheduled">Scheduled</option>
+                <option value="held">Held</option>
+                <option value="cancelled">Cancelled</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Date *</label>
+              <input required type="date" value={form.date} onChange={(e) => setForm({ ...form, date: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Time</label>
+              <input type="time" value={form.time} onChange={(e) => setForm({ ...form, time: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Location</label>
+              <input value={form.location} onChange={(e) => setForm({ ...form, location: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Attendees (comma-separated)</label>
+              <input placeholder="Jane Doe, John Smith" value={form.attendees} onChange={(e) => setForm({ ...form, attendees: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Agenda</label>
+              <textarea rows={4} value={form.agenda} onChange={(e) => setForm({ ...form, agenda: e.target.value })} placeholder="Agenda items..." className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y" />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Minutes</label>
+              <textarea rows={5} value={form.minutes} onChange={(e) => setForm({ ...form, minutes: e.target.value })} placeholder="Meeting minutes..." className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-y" />
+            </div>
+            <div className="sm:col-span-2 flex gap-3 pt-1">
+              <button type="submit" disabled={saving} className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-60 transition-colors">
+                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                {editId ? "Save Changes" : "Create Meeting"}
+              </button>
+              <button type="button" onClick={() => setShowForm(false)} className="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors">Cancel</button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-gray-400"><Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading…</div>
+      ) : meetings.length === 0 ? (
+        <div className="text-center py-16 text-gray-400 text-sm">No board meetings yet.</div>
+      ) : (
+        <div className="space-y-3">
+          {meetings.map((m) => {
+            const attendees = parseAttendees(m.attendees);
+            const expanded = expandedId === m.id;
+            return (
+              <div key={m.id} className="rounded-xl border bg-white shadow-sm overflow-hidden">
+                <div className="flex items-center gap-4 px-5 py-4 cursor-pointer hover:bg-gray-50" onClick={() => setExpandedId(expanded ? null : m.id)}>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-medium text-gray-900 text-sm">{m.title}</span>
+                      <span className={cn("text-[10px] font-medium px-1.5 py-0.5 rounded border", STATUS_STYLES[m.status])}>{m.status}</span>
+                    </div>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      {m.date}{m.time ? ` at ${m.time}` : ""}{m.location ? ` · ${m.location}` : ""}
+                      {attendees.length > 0 && ` · ${attendees.length} attendee${attendees.length !== 1 ? "s" : ""}`}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button onClick={(e) => { e.stopPropagation(); openEdit(m); }} className="text-xs text-blue-600 hover:underline">Edit</button>
+                    <button onClick={(e) => { e.stopPropagation(); del(m.id); }} className="text-red-400 hover:text-red-600"><Trash2 className="h-3.5 w-3.5" /></button>
+                    {expanded ? <ChevronUp className="h-4 w-4 text-gray-400" /> : <ChevronDown className="h-4 w-4 text-gray-400" />}
+                  </div>
+                </div>
+                {expanded && (
+                  <div className="border-t px-5 py-4 space-y-3 bg-gray-50 text-sm">
+                    {attendees.length > 0 && <div><span className="font-medium text-gray-700">Attendees: </span><span className="text-gray-600">{attendees.join(", ")}</span></div>}
+                    {m.agenda && <div><p className="font-medium text-gray-700 mb-1">Agenda</p><pre className="whitespace-pre-wrap text-gray-600 text-xs font-sans">{m.agenda}</pre></div>}
+                    {m.minutes && <div><p className="font-medium text-gray-700 mb-1">Minutes</p><pre className="whitespace-pre-wrap text-gray-600 text-xs font-sans">{m.minutes}</pre></div>}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/app/admin/board/page.tsx
+++ b/app/src/app/admin/board/page.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import {
+  Calendar,
+  FileText,
+  Users,
+  CheckSquare,
+  BookOpen,
+  BarChart2,
+} from "lucide-react";
+
+const BOARD_SECTIONS = [
+  {
+    href: "/admin/board/meetings",
+    icon: Calendar,
+    label: "Board Meetings",
+    description: "Schedule meetings, record agenda & minutes, track attendance.",
+    color: "text-blue-600 bg-blue-50",
+  },
+  {
+    href: "/admin/board/resolutions",
+    icon: FileText,
+    label: "Resolutions & Voting",
+    description: "Record resolutions with yea / nay / abstain vote counts.",
+    color: "text-purple-600 bg-purple-50",
+  },
+  {
+    href: "/admin/board/officer-terms",
+    icon: Users,
+    label: "Officer Terms",
+    description: "Track officer roles and their start / end dates.",
+    color: "text-emerald-600 bg-emerald-50",
+  },
+  {
+    href: "/admin/board/action-items",
+    icon: CheckSquare,
+    label: "Action Items",
+    description: "Kanban board: todo → in progress → done.",
+    color: "text-amber-600 bg-amber-50",
+  },
+  {
+    href: "/admin/board/documents",
+    icon: BookOpen,
+    label: "Document Library",
+    description: "Bylaws, policies, standing rules, and other governance docs.",
+    color: "text-rose-600 bg-rose-50",
+  },
+  {
+    href: "/admin/board/budget",
+    icon: BarChart2,
+    label: "Budget",
+    description: "Annual budget vs. YTD actuals — coming soon.",
+    color: "text-gray-400 bg-gray-50",
+    disabled: true,
+  },
+];
+
+export default function BoardPortalPage() {
+  return (
+    <div>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Board Portal</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Governance tools for board members — meetings, resolutions, officer terms, action items, and documents.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {BOARD_SECTIONS.map(({ href, icon: Icon, label, description, color, disabled }) => {
+          const card = (
+            <div
+              key={href}
+              className={`relative rounded-xl border bg-white p-6 shadow-sm transition-shadow hover:shadow-md ${
+                disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
+              }`}
+            >
+              <div className={`inline-flex rounded-lg p-2 ${color}`}>
+                <Icon className="h-5 w-5" />
+              </div>
+              <h2 className="mt-3 text-base font-semibold text-gray-900">{label}</h2>
+              <p className="mt-1 text-sm text-gray-500">{description}</p>
+              {disabled && (
+                <span className="absolute top-3 right-3 text-xs bg-gray-100 text-gray-400 px-2 py-0.5 rounded-full">
+                  Coming soon
+                </span>
+              )}
+            </div>
+          );
+
+          return disabled ? card : (
+            <Link key={href} href={href}>
+              {card}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/src/app/admin/board/resolutions/page.tsx
+++ b/app/src/app/admin/board/resolutions/page.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { FileText, Plus, X, Loader2, Trash2, Save, ThumbsUp, ThumbsDown, Minus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type ResolutionStatus = "pending" | "passed" | "failed" | "tabled";
+
+interface Resolution {
+  id: string;
+  boardMeetingId: string | null;
+  number: string;
+  title: string;
+  description: string;
+  status: ResolutionStatus;
+  yea: number;
+  nay: number;
+  abstain: number;
+  date: string;
+}
+
+const STATUS_STYLES: Record<ResolutionStatus, string> = {
+  pending: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  passed: "bg-green-50 text-green-700 border-green-200",
+  failed: "bg-red-50 text-red-700 border-red-200",
+  tabled: "bg-gray-50 text-gray-600 border-gray-200",
+};
+
+const formDefaults = {
+  number: "", title: "", description: "", status: "pending" as ResolutionStatus,
+  yea: 0, nay: 0, abstain: 0, date: "", boardMeetingId: "",
+};
+
+export default function ResolutionsPage() {
+  const [items, setItems] = useState<Resolution[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [form, setForm] = useState(formDefaults);
+
+  const fetch_ = useCallback(async () => {
+    setLoading(true);
+    const res = await fetch("/api/board/resolutions");
+    setItems(await res.json());
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetch_(); }, [fetch_]);
+
+  function openCreate() { setForm(formDefaults); setEditId(null); setShowForm(true); }
+  function openEdit(r: Resolution) {
+    setForm({ number: r.number, title: r.title, description: r.description, status: r.status, yea: r.yea, nay: r.nay, abstain: r.abstain, date: r.date, boardMeetingId: r.boardMeetingId ?? "" });
+    setEditId(r.id); setShowForm(true);
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault(); setSaving(true);
+    if (editId) {
+      await fetch(`/api/board/resolutions/${editId}`, { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(form) });
+    } else {
+      await fetch("/api/board/resolutions", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(form) });
+    }
+    setSaving(false); setShowForm(false); fetch_();
+  }
+
+  async function del(id: string) {
+    if (!confirm("Delete this resolution?")) return;
+    await fetch(`/api/board/resolutions/${id}`, { method: "DELETE" });
+    fetch_();
+  }
+
+  const n = (v: string | number) => Number(v);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2"><FileText className="h-6 w-6 text-purple-600" /> Resolutions &amp; Voting</h1>
+          <p className="text-sm text-gray-500 mt-0.5">Record board resolutions with vote counts.</p>
+        </div>
+        <button onClick={openCreate} className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-purple-600 text-white text-sm font-medium hover:bg-purple-700 transition-colors">
+          <Plus className="h-4 w-4" /> New Resolution
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="mb-6 rounded-xl border bg-white shadow-sm p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-base font-semibold text-gray-900">{editId ? "Edit Resolution" : "New Resolution"}</h2>
+            <button onClick={() => setShowForm(false)}><X className="h-4 w-4 text-gray-400 hover:text-gray-600" /></button>
+          </div>
+          <form onSubmit={submit} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Resolution # (e.g. 2024-001)</label>
+              <input value={form.number} onChange={(e) => setForm({ ...form, number: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500" />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Date</label>
+              <input type="date" value={form.date} onChange={(e) => setForm({ ...form, date: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500" />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Title *</label>
+              <input required value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500" />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="block text-xs font-medium text-gray-700 mb-1">Description</label>
+              <textarea rows={3} value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 resize-y" />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">Status</label>
+              <select value={form.status} onChange={(e) => setForm({ ...form, status: e.target.value as ResolutionStatus })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500">
+                <option value="pending">Pending</option>
+                <option value="passed">Passed</option>
+                <option value="failed">Failed</option>
+                <option value="tabled">Tabled</option>
+              </select>
+            </div>
+            <div className="grid grid-cols-3 gap-2">
+              {(["yea", "nay", "abstain"] as const).map((field) => (
+                <div key={field}>
+                  <label className="block text-xs font-medium text-gray-700 mb-1 capitalize">{field}</label>
+                  <input type="number" min={0} value={form[field]} onChange={(e) => setForm({ ...form, [field]: n(e.target.value) })} className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-purple-500" />
+                </div>
+              ))}
+            </div>
+            <div className="sm:col-span-2 flex gap-3 pt-1">
+              <button type="submit" disabled={saving} className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-purple-600 text-white text-sm font-medium hover:bg-purple-700 disabled:opacity-60 transition-colors">
+                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                {editId ? "Save Changes" : "Create Resolution"}
+              </button>
+              <button type="button" onClick={() => setShowForm(false)} className="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors">Cancel</button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-gray-400"><Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading…</div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-16 text-gray-400 text-sm">No resolutions yet.</div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border bg-white shadow-sm">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b">
+              <tr>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500">#</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500">Title</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500">Date</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-gray-500">Status</th>
+                <th className="text-center px-4 py-3 text-xs font-medium text-gray-500">Yea</th>
+                <th className="text-center px-4 py-3 text-xs font-medium text-gray-500">Nay</th>
+                <th className="text-center px-4 py-3 text-xs font-medium text-gray-500">Abstain</th>
+                <th className="px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {items.map((r) => (
+                <tr key={r.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-gray-500 text-xs">{r.number || "—"}</td>
+                  <td className="px-4 py-3 font-medium text-gray-900 max-w-xs truncate">{r.title}</td>
+                  <td className="px-4 py-3 text-gray-500">{r.date || "—"}</td>
+                  <td className="px-4 py-3">
+                    <span className={cn("text-[10px] font-medium px-1.5 py-0.5 rounded border", STATUS_STYLES[r.status])}>{r.status}</span>
+                  </td>
+                  <td className="px-4 py-3 text-center text-green-600 font-medium">{r.yea}</td>
+                  <td className="px-4 py-3 text-center text-red-500 font-medium">{r.nay}</td>
+                  <td className="px-4 py-3 text-center text-gray-400 font-medium">{r.abstain}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2 justify-end">
+                      <button onClick={() => openEdit(r)} className="text-xs text-blue-600 hover:underline">Edit</button>
+                      <button onClick={() => del(r.id)} className="text-red-400 hover:text-red-600"><Trash2 className="h-3.5 w-3.5" /></button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/app/admin/integrations/page.tsx
+++ b/app/src/app/admin/integrations/page.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Plug,
+  CheckCircle2,
+  XCircle,
+  RefreshCw,
+  Mail,
+  List,
+  Clock,
+  AlertCircle,
+  ChevronDown,
+  LogOut,
+  Zap,
+} from "lucide-react";
+
+type Segment = "all_members" | "board" | "external_community" | "potential_members" | "full_list";
+
+const SEGMENT_LABELS: Record<Segment, string> = {
+  all_members: "All Members",
+  board: "Board",
+  external_community: "External / Community",
+  potential_members: "Potential Members",
+  full_list: "Full List",
+};
+const ALL_SEGMENTS = Object.keys(SEGMENT_LABELS) as Segment[];
+
+interface CCList { list_id: string; name: string; membership_count?: number }
+interface Mapping { segment: string; ccListId: string; ccListName: string; enabled: boolean }
+interface SyncLog {
+  id: string;
+  segment: string;
+  status: "success" | "partial" | "failed";
+  recordsSynced: number;
+  recordsFailed: number;
+  errorMessage?: string;
+  triggeredBy: string;
+  createdAt: string;
+}
+
+export default function IntegrationsPage() {
+  const [connected, setConnected] = useState(false);
+  const [schedule, setSchedule] = useState<"manual" | "nightly" | "weekly">("manual");
+  const [ccLists, setCcLists] = useState<CCList[]>([]);
+  const [mappings, setMappings] = useState<Mapping[]>([]);
+  const [logs, setLogs] = useState<SyncLog[]>([]);
+  const [syncing, setSyncing] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [listsLoading, setListsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const flash = (msg: string) => {
+    setSuccessMsg(msg);
+    setTimeout(() => setSuccessMsg(null), 3000);
+  };
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/integrations/constant-contact/status");
+      const data = await res.json();
+      setConnected(data.connected ?? false);
+      setSchedule(data.syncSchedule ?? "manual");
+      setMappings(data.mappings ?? []);
+    } catch { /* ignore */ }
+    try {
+      const res = await fetch("/api/integrations/constant-contact/logs?limit=30");
+      const data = await res.json();
+      if (Array.isArray(data)) setLogs(data);
+    } catch { /* ignore */ }
+    setLoading(false);
+  }, []);
+
+  const loadCcLists = async () => {
+    setListsLoading(true);
+    try {
+      const res = await fetch("/api/integrations/constant-contact/lists");
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data)) setCcLists(data);
+        else setError("Failed to fetch CC lists");
+      } else {
+        const d = await res.json();
+        setError(d.error ?? "Failed to fetch lists");
+      }
+    } catch { setError("Network error"); }
+    setListsLoading(false);
+  };
+
+  useEffect(() => {
+    loadStatus();
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("connected") === "true") flash("Successfully connected to Constant Contact!");
+    if (params.get("error")) setError(`OAuth error: ${params.get("error")}`);
+  }, [loadStatus]);
+
+  useEffect(() => {
+    if (connected) loadCcLists();
+  }, [connected]);
+
+  const handleConnect = () => {
+    window.location.href = "/api/integrations/constant-contact/auth";
+  };
+
+  const handleDisconnect = async () => {
+    if (!confirm("Disconnect Constant Contact? Sync will stop until reconnected.")) return;
+    await fetch("/api/integrations/constant-contact/disconnect", { method: "POST" });
+    setConnected(false);
+    flash("Disconnected.");
+  };
+
+  const handleSync = async (segment: Segment | "all") => {
+    setSyncing(segment);
+    setError(null);
+    try {
+      const res = await fetch("/api/integrations/constant-contact/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ segment }),
+      });
+      const data = await res.json();
+      if (!res.ok) { setError(data.error ?? "Sync failed"); return; }
+      flash(segment === "all" ? "All segments synced!" : `Synced ${SEGMENT_LABELS[segment]}!`);
+      await loadStatus();
+    } catch { setError("Network error during sync"); }
+    setSyncing(null);
+  };
+
+  const handleMappingChange = async (segment: Segment, listId: string) => {
+    const list = ccLists.find((l) => l.list_id === listId);
+    await fetch("/api/integrations/constant-contact/mappings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ segment, ccListId: listId, ccListName: list?.name ?? "" }),
+    });
+    setMappings((prev) => {
+      const next = prev.filter((m) => m.segment !== segment);
+      return [...next, { segment, ccListId: listId, ccListName: list?.name ?? "", enabled: true }];
+    });
+  };
+
+  const handleScheduleChange = async (s: "manual" | "nightly" | "weekly") => {
+    setSchedule(s);
+    await fetch("/api/integrations/constant-contact/schedule", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ syncSchedule: s }),
+    });
+    flash("Schedule updated.");
+  };
+
+  const getMappingForSegment = (segment: Segment) =>
+    mappings.find((m) => m.segment === segment);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <RefreshCw className="w-6 h-6 text-gray-400 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-600 to-blue-800 flex items-center justify-center">
+          <Plug className="w-5 h-5 text-white" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Integrations</h1>
+          <p className="text-sm text-gray-500">Connect your Constant Contact account and manage email list sync</p>
+        </div>
+      </div>
+
+      {/* Alerts */}
+      {successMsg && (
+        <div className="flex items-center gap-2 px-4 py-3 bg-green-50 border border-green-200 rounded-xl text-sm text-green-800">
+          <CheckCircle2 className="w-4 h-4 shrink-0" />
+          {successMsg}
+        </div>
+      )}
+      {error && (
+        <div className="flex items-center gap-2 px-4 py-3 bg-red-50 border border-red-200 rounded-xl text-sm text-red-800">
+          <AlertCircle className="w-4 h-4 shrink-0" />
+          {error}
+          <button className="ml-auto text-red-500 hover:text-red-700" onClick={() => setError(null)}>✕</button>
+        </div>
+      )}
+
+      {/* Connection Card */}
+      <section>
+        <h2 className="text-base font-semibold text-gray-900 mb-3 flex items-center gap-2">
+          <Mail className="w-4 h-4 text-gray-500" />
+          Constant Contact
+        </h2>
+        <div className="rounded-xl border border-gray-200 bg-white p-5">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {connected ? (
+                <CheckCircle2 className="w-5 h-5 text-green-500" />
+              ) : (
+                <XCircle className="w-5 h-5 text-gray-400" />
+              )}
+              <div>
+                <p className="font-medium text-gray-900 text-sm">
+                  {connected ? "Connected" : "Not connected"}
+                </p>
+                <p className="text-xs text-gray-500">
+                  {connected
+                    ? "OAuth 2.0 connection active — contacts will sync to your CC lists"
+                    : "Connect your Constant Contact account to enable email list sync"}
+                </p>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              {connected ? (
+                <>
+                  <button
+                    onClick={() => loadCcLists()}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50"
+                    disabled={listsLoading}
+                  >
+                    <RefreshCw className={`w-3 h-3 ${listsLoading ? "animate-spin" : ""}`} />
+                    Refresh Lists
+                  </button>
+                  <button
+                    onClick={handleDisconnect}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-600 border border-red-200 rounded-lg hover:bg-red-50"
+                  >
+                    <LogOut className="w-3 h-3" />
+                    Disconnect
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={handleConnect}
+                  className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700"
+                >
+                  <Plug className="w-3.5 h-3.5" />
+                  Connect Constant Contact
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {connected && (
+        <>
+          {/* Sync Schedule */}
+          <section>
+            <h2 className="text-base font-semibold text-gray-900 mb-3 flex items-center gap-2">
+              <Clock className="w-4 h-4 text-gray-500" />
+              Sync Schedule
+            </h2>
+            <div className="rounded-xl border border-gray-200 bg-white p-5">
+              <p className="text-sm text-gray-600 mb-4">
+                Choose how often member data is pushed to Constant Contact. Manual means you trigger each sync.
+              </p>
+              <div className="flex gap-3">
+                {(["manual", "nightly", "weekly"] as const).map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => handleScheduleChange(s)}
+                    className={`px-4 py-2 rounded-lg text-sm font-medium border transition-all ${
+                      schedule === s
+                        ? "bg-blue-600 text-white border-blue-600"
+                        : "text-gray-700 border-gray-200 hover:bg-gray-50"
+                    }`}
+                  >
+                    {s === "manual" ? "Manual only" : s === "nightly" ? "Nightly" : "Weekly"}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-gray-400 mt-3">
+                Note: Scheduled syncs require a cron job or external scheduler to call the sync API endpoint.
+              </p>
+            </div>
+          </section>
+
+          {/* Segment Mappings */}
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-base font-semibold text-gray-900 flex items-center gap-2">
+                <List className="w-4 h-4 text-gray-500" />
+                Segment Mappings
+              </h2>
+              <button
+                onClick={() => handleSync("all")}
+                disabled={syncing !== null}
+                className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+              >
+                <Zap className={`w-3.5 h-3.5 ${syncing === "all" ? "animate-pulse" : ""}`} />
+                {syncing === "all" ? "Syncing…" : "Sync All"}
+              </button>
+            </div>
+            <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+              <div className="divide-y divide-gray-100">
+                {ALL_SEGMENTS.map((segment) => {
+                  const mapping = getMappingForSegment(segment);
+                  return (
+                    <div key={segment} className="flex items-center justify-between px-5 py-4">
+                      <div>
+                        <p className="text-sm font-medium text-gray-900">{SEGMENT_LABELS[segment]}</p>
+                        <p className="text-xs text-gray-500">
+                          {mapping?.ccListName ? `→ ${mapping.ccListName}` : "Not mapped to a CC list"}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <div className="relative">
+                          <select
+                            value={mapping?.ccListId ?? ""}
+                            onChange={(e) => handleMappingChange(segment, e.target.value)}
+                            className="appearance-none pl-3 pr-8 py-1.5 text-sm border border-gray-200 rounded-lg bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                          >
+                            <option value="">— select list —</option>
+                            {ccLists.map((l) => (
+                              <option key={l.list_id} value={l.list_id}>{l.name}</option>
+                            ))}
+                          </select>
+                          <ChevronDown className="absolute right-2 top-2 w-4 h-4 text-gray-400 pointer-events-none" />
+                        </div>
+                        <button
+                          onClick={() => handleSync(segment)}
+                          disabled={syncing !== null || !mapping?.ccListId}
+                          className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-blue-700 border border-blue-200 rounded-lg hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                        >
+                          <RefreshCw className={`w-3 h-3 ${syncing === segment ? "animate-spin" : ""}`} />
+                          {syncing === segment ? "Syncing…" : "Sync"}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            {ccLists.length === 0 && (
+              <p className="text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-lg px-4 py-2 mt-2">
+                No CC lists loaded. Click &quot;Refresh Lists&quot; to fetch your Constant Contact lists.
+              </p>
+            )}
+          </section>
+
+          {/* Sync Logs */}
+          <section>
+            <h2 className="text-base font-semibold text-gray-900 mb-3 flex items-center gap-2">
+              <Clock className="w-4 h-4 text-gray-500" />
+              Sync Logs
+            </h2>
+            {logs.length === 0 ? (
+              <div className="rounded-xl border border-gray-200 bg-white px-5 py-10 text-center text-sm text-gray-400">
+                No sync activity yet. Run a sync to get started.
+              </div>
+            ) : (
+              <div className="rounded-xl border border-gray-200 bg-white overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-50 text-xs text-gray-500 uppercase tracking-wide">
+                    <tr>
+                      <th className="px-5 py-3 text-left">Timestamp</th>
+                      <th className="px-5 py-3 text-left">Segment</th>
+                      <th className="px-5 py-3 text-left">Status</th>
+                      <th className="px-5 py-3 text-left">Synced</th>
+                      <th className="px-5 py-3 text-left">Failed</th>
+                      <th className="px-5 py-3 text-left">Trigger</th>
+                      <th className="px-5 py-3 text-left">Error</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {logs.map((log) => (
+                      <tr key={log.id} className="hover:bg-gray-50">
+                        <td className="px-5 py-3 text-gray-600 whitespace-nowrap">
+                          {new Date(log.createdAt).toLocaleString()}
+                        </td>
+                        <td className="px-5 py-3 font-medium text-gray-800">
+                          {SEGMENT_LABELS[log.segment as Segment] ?? log.segment}
+                        </td>
+                        <td className="px-5 py-3">
+                          <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                            log.status === "success"
+                              ? "bg-green-100 text-green-700"
+                              : log.status === "partial"
+                              ? "bg-amber-100 text-amber-700"
+                              : "bg-red-100 text-red-700"
+                          }`}>
+                            {log.status === "success" ? "✓" : log.status === "partial" ? "~" : "✗"}
+                            {log.status}
+                          </span>
+                        </td>
+                        <td className="px-5 py-3 text-gray-700">{log.recordsSynced}</td>
+                        <td className="px-5 py-3 text-gray-700">{log.recordsFailed}</td>
+                        <td className="px-5 py-3 text-gray-500 capitalize">{log.triggeredBy}</td>
+                        <td className="px-5 py-3 text-red-600 text-xs max-w-[200px] truncate">
+                          {log.errorMessage ?? "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/src/app/api/admin/announcements/[id]/route.ts
+++ b/app/src/app/api/admin/announcements/[id]/route.ts
@@ -2,35 +2,35 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import { getAnnouncementById, updateAnnouncement, deleteAnnouncement } from "@/lib/queries/announcements";
+import { validate } from "@/lib/validations/api-validate";
+import { updateAnnouncementSchema } from "@/lib/validations";
 
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const body = await req.json();
-
+  const validated = validate(body, updateAnnouncementSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
   try {
-    // Handle publish/unpublish action
-    if (body.action === "publish") {
+    if (data.action === "publish") {
       const updated = await updateAnnouncement(id, { publishedAt: new Date() });
       return NextResponse.json(updated);
     }
-    if (body.action === "unpublish") {
+    if (data.action === "unpublish") {
       const updated = await updateAnnouncement(id, { publishedAt: null });
       return NextResponse.json(updated);
     }
-
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { action: _action, publish: publishFlag, ...data } = body;
-    // Handle publish boolean from edit modal
+    const { action: _action, publish: publishFlag, ...rest } = data;
+    const updateData: Record<string, unknown> = { ...rest };
     if (typeof publishFlag === "boolean") {
-      data.publishedAt = publishFlag ? new Date() : null;
+      updateData.publishedAt = publishFlag ? new Date() : null;
     }
-    const updated = await updateAnnouncement(id, data);
+    const updated = await updateAnnouncement(id, updateData);
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(updated);
   } catch (err) {
@@ -42,14 +42,11 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const item = await getAnnouncementById(id);
   if (!item) return NextResponse.json({ error: "Not found" }, { status: 404 });
-
   try {
     await deleteAnnouncement(id);
     return NextResponse.json({ success: true });

--- a/app/src/app/api/admin/announcements/route.ts
+++ b/app/src/app/api/admin/announcements/route.ts
@@ -4,52 +4,44 @@ import { hasAnyRole } from "@/lib/auth";
 import { getUserByClerkId } from "@/lib/queries/users";
 import { getAllAnnouncements, createAnnouncement } from "@/lib/queries/announcements";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createAnnouncementSchema } from "@/lib/validations";
 
 export async function GET() {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const items = await getAllAnnouncements();
     return NextResponse.json(items);
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json([]);
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const dbUser = await getUserByClerkId(userId);
     if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
     const body = await req.json();
-    const { title, content, category, pinned, publish } = body;
-
-    if (!title || !content) {
-      return NextResponse.json({ error: "title and content required" }, { status: 400 });
-    }
-
+    const validated = validate(body, createAnnouncementSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const announcement = await createAnnouncement({
       id: generateId(),
-      title,
-      content,
-      category: category ?? "general",
+      title: data.title,
+      content: data.content,
+      category: data.category,
       authorId: dbUser.id,
-      pinned: pinned ?? false,
-      publishedAt: publish ? new Date() : null,
+      pinned: data.pinned,
+      publishedAt: data.publish ? new Date() : null,
     });
-
     return NextResponse.json(announcement, { status: 201 });
   } catch (err) {
     console.error("Create announcement error:", err);

--- a/app/src/app/api/admin/attendance/bulk/route.ts
+++ b/app/src/app/api/admin/attendance/bulk/route.ts
@@ -6,48 +6,33 @@ import { db } from "@/lib/db/client";
 import { attendance } from "@/lib/db/schema";
 import { generateId } from "@/lib/utils";
 import { sql } from "drizzle-orm";
+import { validate } from "@/lib/validations/api-validate";
+import { bulkAttendanceSchema } from "@/lib/validations";
 
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const body = await req.json();
-    // date: 'YYYY-MM-DD', attendees: string[] (user IDs), type: 'regular' | 'makeup'
-    const { date, attendees, type = "regular" } = body;
-
-    if (!date || !Array.isArray(attendees)) {
-      return NextResponse.json({ error: "date and attendees required" }, { status: 400 });
-    }
-
+    const validated = validate(body, bulkAttendanceSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const dbUser = await getUserByClerkId(userId);
     if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
-    const records = attendees.map((uid: string) => ({
+    const records = data.attendees.map((uid: string) => ({
       id: generateId(),
       userId: uid,
-      date,
-      type,
+      date: data.date,
+      type: data.type,
       recordedBy: dbUser.id,
       notes: "",
     }));
-
-    if (records.length === 0) {
-      return NextResponse.json({ inserted: 0 });
-    }
-
-    // Upsert — ignore conflicts (same user/date/type)
-    await db
-      .insert(attendance)
-      .values(records)
-      .onConflictDoUpdate({
-        target: [attendance.userId, attendance.date, attendance.type],
-        set: { recordedBy: sql`excluded.recorded_by` },
-      });
-
+    await db.insert(attendance).values(records).onConflictDoUpdate({
+      target: [attendance.userId, attendance.date, attendance.type],
+      set: { recordedBy: sql`excluded.recorded_by` },
+    });
     return NextResponse.json({ inserted: records.length });
   } catch (err) {
     console.error("Bulk attendance error:", err);

--- a/app/src/app/api/admin/committees/[id]/route.ts
+++ b/app/src/app/api/admin/committees/[id]/route.ts
@@ -2,28 +2,21 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import {
-  getCommitteeById,
-  getCommitteeWithMembers,
-  updateCommittee,
-  addCommitteeMember,
-  removeCommitteeMember,
+  getCommitteeById, getCommitteeWithMembers, updateCommittee,
+  addCommitteeMember, removeCommitteeMember,
 } from "@/lib/queries/committees-club";
+import { validate } from "@/lib/validations/api-validate";
+import { updateCommitteeSchema } from "@/lib/validations";
 
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const url = new URL(req.url);
   const withMembers = url.searchParams.get("members") === "true";
-
-  const committee = withMembers
-    ? await getCommitteeWithMembers(id)
-    : await getCommitteeById(id);
-
+  const committee = withMembers ? await getCommitteeWithMembers(id) : await getCommitteeById(id);
   if (!committee) return NextResponse.json({ error: "Not found" }, { status: 404 });
   return NextResponse.json(committee);
 }
@@ -31,28 +24,27 @@ export async function GET(req: Request, { params }: { params: Promise<{ id: stri
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const body = await req.json();
-
+  const validated = validate(body, updateCommitteeSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
   try {
-    // Add member action
-    if (body.action === "add_member") {
-      const membership = await addCommitteeMember(id, body.userId, body.role ?? "member");
+    if (data.action === "add_member") {
+      if (!data.userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
+      const membership = await addCommitteeMember(id, data.userId, data.role ?? "member");
       return NextResponse.json(membership);
     }
-    // Remove member action
-    if (body.action === "remove_member") {
-      await removeCommitteeMember(id, body.userId);
+    if (data.action === "remove_member") {
+      if (!data.userId) return NextResponse.json({ error: "userId required" }, { status: 400 });
+      await removeCommitteeMember(id, data.userId);
       return NextResponse.json({ success: true });
     }
-
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { action: _action, ...data } = body;
-    const updated = await updateCommittee(id, data);
+    const { action: _a, userId: _u, role: _r, ...updateData } = data;
+    const updated = await updateCommittee(id, updateData);
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(updated);
   } catch (err) {

--- a/app/src/app/api/admin/committees/route.ts
+++ b/app/src/app/api/admin/committees/route.ts
@@ -3,46 +3,41 @@ import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import { getAllCommittees, createCommittee } from "@/lib/queries/committees-club";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createCommitteeSchema } from "@/lib/validations";
 
 export async function GET() {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const items = await getAllCommittees();
     return NextResponse.json(items);
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json([]);
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const body = await req.json();
-    const { name, description, category, chairUserId } = body;
-
-    if (!name) return NextResponse.json({ error: "Name required" }, { status: 400 });
-
+    const validated = validate(body, createCommitteeSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const committee = await createCommittee({
       id: generateId(),
-      name,
-      description: description ?? "",
-      category: category ?? "standing",
-      chairUserId: chairUserId ?? null,
-      active: true,
+      name: data.name,
+      description: data.description,
+      category: data.category,
+      chairUserId: data.chairUserId ?? null,
+      active: data.active,
     });
-
     return NextResponse.json(committee, { status: 201 });
   } catch (err) {
     console.error("Create committee error:", err);

--- a/app/src/app/api/admin/events/[id]/route.ts
+++ b/app/src/app/api/admin/events/[id]/route.ts
@@ -3,14 +3,14 @@ import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import { getUserByClerkId } from "@/lib/queries/users";
 import { getClubEventById, updateClubEvent, approveClubEvent, deleteClubEvent } from "@/lib/queries/events-club";
+import { validate } from "@/lib/validations/api-validate";
+import { adminUpdateEventSchema } from "@/lib/validations";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const evt = await getClubEventById(id);
   if (!evt) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -20,27 +20,27 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const body = await req.json();
-
+  const validated = validate(body, adminUpdateEventSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
   try {
-    // Special action: approve
-    if (body.action === "approve") {
+    if (data.action === "approve") {
       const dbUser = await getUserByClerkId(userId);
       if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
       const evt = await approveClubEvent(id, dbUser.id);
       return NextResponse.json(evt);
     }
-    // Special action: reject/cancel
-    if (body.action === "reject") {
+    if (data.action === "reject") {
       const evt = await updateClubEvent(id, { status: "cancelled" });
       return NextResponse.json(evt);
     }
-    const evt = await updateClubEvent(id, body);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { action: _action, ...updateData } = data;
+    const evt = await updateClubEvent(id, updateData);
     if (!evt) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(evt);
   } catch (err) {
@@ -52,10 +52,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   try {
     await deleteClubEvent(id);

--- a/app/src/app/api/admin/events/route.ts
+++ b/app/src/app/api/admin/events/route.ts
@@ -4,37 +4,44 @@ import { hasAnyRole } from "@/lib/auth";
 import { getUserByClerkId } from "@/lib/queries/users";
 import { getAllClubEvents, createClubEvent } from "@/lib/queries/events-club";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createEventSchema } from "@/lib/validations";
 
 export async function GET() {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const evts = await getAllClubEvents();
     return NextResponse.json(evts);
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json([]);
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const dbUser = await getUserByClerkId(userId);
     if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
     const body = await req.json();
-    const evt = await createClubEvent({ id: generateId(), submittedBy: dbUser.id, ...body });
+    const validated = validate(body, createEventSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const evt = await createClubEvent({
+      id: generateId(),
+      submittedBy: dbUser.id,
+      ...data,
+      status: "pending",
+      approvedBy: null,
+      slug: null,
+      imageUrl: null,
+    });
     return NextResponse.json(evt, { status: 201 });
   } catch (err) {
     console.error("Create event error:", err);

--- a/app/src/app/api/admin/members/[id]/route.ts
+++ b/app/src/app/api/admin/members/[id]/route.ts
@@ -2,14 +2,14 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import { getUserById, updateUser, deleteUser } from "@/lib/queries/users";
+import { validate } from "@/lib/validations/api-validate";
+import { updateMemberSchema } from "@/lib/validations";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const member = await getUserById(id);
   if (!member) return NextResponse.json({ error: "Not found" }, { status: 404 });
@@ -19,27 +19,17 @@ export async function GET(_req: Request, { params }: { params: Promise<{ id: str
 export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   const body = await req.json();
-
-  // Allowlist fields to prevent mass assignment
-  const ALLOWED_FIELDS = ["firstName", "lastName", "phone", "company", "classification", "memberType", "status", "bio", "address", "photoUrl", "roles"] as const;
-  const data: Record<string, unknown> = {};
-  for (const key of ALLOWED_FIELDS) {
-    if (key in body) data[key] = body[key];
-  }
-
-  // Serialize roles array to JSON string if provided
-  if (Array.isArray(data.roles)) {
-    data.roles = JSON.stringify(data.roles);
-  }
-
+  const validated = validate(body, updateMemberSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
+  const updateData: Record<string, unknown> = { ...data };
+  if (Array.isArray(data.roles)) updateData.roles = JSON.stringify(data.roles);
   try {
-    const updated = await updateUser(id, data);
+    const updated = await updateUser(id, updateData);
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(updated);
   } catch (err) {
@@ -51,11 +41,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  // Only super_admin can delete members
   const isSuperAdmin = await hasAnyRole(userId, ["super_admin"]);
   if (!isSuperAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   try {
     await deleteUser(id);

--- a/app/src/app/api/admin/members/import/route.ts
+++ b/app/src/app/api/admin/members/import/route.ts
@@ -3,14 +3,13 @@ import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import { createUser } from "@/lib/queries/users";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { importMembersSchema } from "@/lib/validations";
 
-// Simple CSV parser — handles quoted fields
 function parseCSV(text: string): Record<string, string>[] {
   const lines = text.split(/\r?\n/).filter((l) => l.trim());
   if (lines.length < 2) return [];
-
   const headers = lines[0].split(",").map((h) => h.trim().replace(/^"|"$/g, "").toLowerCase());
-
   return lines
     .slice(1)
     .map((line) => {
@@ -18,17 +17,11 @@ function parseCSV(text: string): Record<string, string>[] {
       let current = "";
       let inQuotes = false;
       for (const ch of line) {
-        if (ch === '"') {
-          inQuotes = !inQuotes;
-        } else if (ch === "," && !inQuotes) {
-          values.push(current.trim());
-          current = "";
-        } else {
-          current += ch;
-        }
+        if (ch === '"') { inQuotes = !inQuotes; }
+        else if (ch === "," && !inQuotes) { values.push(current.trim()); current = ""; }
+        else { current += ch; }
       }
       values.push(current.trim());
-
       return headers.reduce<Record<string, string>>((obj, header, i) => {
         obj[header] = values[i] ?? "";
         return obj;
@@ -37,7 +30,6 @@ function parseCSV(text: string): Record<string, string>[] {
     .filter((row) => row.email || row["e-mail"]);
 }
 
-// Normalize column names from DACdb-style CSVs
 function normalizeRow(row: Record<string, string>) {
   return {
     email: row.email || row["e-mail"] || row["email address"] || "",
@@ -53,48 +45,36 @@ function normalizeRow(row: Record<string, string>) {
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const body = await req.json();
-    const { csvText, preview } = body;
-
-    if (!csvText) return NextResponse.json({ error: "CSV text required" }, { status: 400 });
-
-    const rows = parseCSV(csvText);
+    const validated = validate(body, importMembersSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const rows = parseCSV(data.csvText);
     const normalized = rows.map(normalizeRow).filter((r) => r.email);
-
-    // Preview mode — just return parsed data without inserting
-    if (preview) {
-      return NextResponse.json({ rows: normalized, count: normalized.length });
-    }
-
-    // Import mode — insert all rows
+    if (data.preview) return NextResponse.json({ rows: normalized, count: normalized.length });
     const results = await Promise.allSettled(
-      normalized.map((data) => {
+      normalized.map((row) => {
         const id = generateId();
         return createUser({
           id,
           clerkId: `import_${id}`,
-          email: data.email,
-          firstName: data.firstName,
-          lastName: data.lastName,
-          phone: data.phone,
-          company: data.company,
-          classification: data.classification,
-          memberType: ["active", "honorary", "alumni", "leave", "prospect"].includes(data.memberType)
-            ? data.memberType
-            : "active",
+          email: row.email,
+          firstName: row.firstName,
+          lastName: row.lastName,
+          phone: row.phone,
+          company: row.company,
+          classification: row.classification,
+          memberType: ["active", "honorary", "alumni", "leave", "prospect"].includes(row.memberType)
+            ? row.memberType : "active",
           roles: JSON.stringify(["member"]),
         });
       })
     );
-
     const succeeded = results.filter((r) => r.status === "fulfilled").length;
     const failed = results.filter((r) => r.status === "rejected").length;
-
     return NextResponse.json({ imported: succeeded, failed, total: normalized.length });
   } catch (err) {
     console.error("Import members error:", err);

--- a/app/src/app/api/admin/members/invite/route.ts
+++ b/app/src/app/api/admin/members/invite/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
+import { validate } from "@/lib/validations/api-validate";
+import { inviteMemberSchema } from "@/lib/validations";
 
 export async function POST(req: Request) {
   const { userId } = await auth();
@@ -10,18 +12,18 @@ export async function POST(req: Request) {
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const body = await req.json();
-  const { email, firstName, lastName, roles } = body;
-
-  if (!email) return NextResponse.json({ error: "Email required" }, { status: 400 });
+  const validated = validate(body, inviteMemberSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
 
   try {
     const clerk = await clerkClient();
     const invitation = await clerk.invitations.createInvitation({
-      emailAddress: email,
+      emailAddress: data.email,
       publicMetadata: {
-        roles: roles ?? ["member"],
-        firstName: firstName ?? "",
-        lastName: lastName ?? "",
+        roles: data.roles,
+        firstName: data.firstName,
+        lastName: data.lastName,
       },
       redirectUrl: `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/register`,
     });

--- a/app/src/app/api/admin/members/invite/route.ts
+++ b/app/src/app/api/admin/members/invite/route.ts
@@ -7,15 +7,12 @@ import { inviteMemberSchema } from "@/lib/validations";
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const body = await req.json();
   const validated = validate(body, inviteMemberSchema);
   if (validated instanceof NextResponse) return validated;
   const { data } = validated;
-
   try {
     const clerk = await clerkClient();
     const invitation = await clerk.invitations.createInvitation({
@@ -27,7 +24,6 @@ export async function POST(req: Request) {
       },
       redirectUrl: `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/register`,
     });
-
     return NextResponse.json({ success: true, invitationId: invitation.id });
   } catch (err: unknown) {
     console.error("Invite member error:", err);

--- a/app/src/app/api/admin/members/route.ts
+++ b/app/src/app/api/admin/members/route.ts
@@ -3,51 +3,46 @@ import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import { getAllUsers, createUser } from "@/lib/queries/users";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createMemberSchema } from "@/lib/validations";
 
 export async function GET() {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const members = await getAllUsers();
     return NextResponse.json(members);
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json([], { status: 200 });
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const body = await req.json();
-    const { email, firstName, lastName, phone, company, classification, memberType, roles } = body;
-
-    if (!email) return NextResponse.json({ error: "Email required" }, { status: 400 });
-
+    const validated = validate(body, createMemberSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const id = generateId();
     const member = await createUser({
       id,
-      clerkId: `manual_${id}`, // Will be updated when user registers
-      email,
-      firstName: firstName ?? "",
-      lastName: lastName ?? "",
-      phone: phone ?? "",
-      company: company ?? "",
-      classification: classification ?? "",
-      memberType: memberType ?? "active",
-      roles: JSON.stringify(roles ?? ["member"]),
+      clerkId: `manual_${id}`,
+      email: data.email,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      phone: data.phone,
+      company: data.company,
+      classification: data.classification,
+      memberType: data.memberType,
+      roles: JSON.stringify(data.roles),
     });
-
     return NextResponse.json(member, { status: 201 });
   } catch (err) {
     console.error("Create member error:", err);

--- a/app/src/app/api/admin/planning/health/route.ts
+++ b/app/src/app/api/admin/planning/health/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { hasRole } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { sql } from "drizzle-orm";
+import { env } from "@/lib/env";
 
 export async function GET() {
   const { userId } = await auth();
@@ -12,15 +13,16 @@ export async function GET() {
   if (!isSuperAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   // Check env vars (boolean only, never expose values)
+  // These are already validated at startup by env.ts — if we reach here they're set.
   const envVars: Record<string, boolean> = {
-    DATABASE_URL: !!process.env.DATABASE_URL,
-    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
-    CLERK_SECRET_KEY: !!process.env.CLERK_SECRET_KEY,
-    ANTHROPIC_API_KEY: !!process.env.ANTHROPIC_API_KEY,
-    NEXT_PUBLIC_CLERK_SIGN_IN_URL: !!process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,
-    NEXT_PUBLIC_CLERK_SIGN_UP_URL: !!process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL,
-    NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: !!process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL,
-    NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: !!process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL,
+    DATABASE_URL: !!env.DATABASE_URL,
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: !!env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    CLERK_SECRET_KEY: !!env.CLERK_SECRET_KEY,
+    ANTHROPIC_API_KEY: !!env.ANTHROPIC_API_KEY,
+    NEXT_PUBLIC_CLERK_SIGN_IN_URL: !!env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,
+    NEXT_PUBLIC_CLERK_SIGN_UP_URL: !!env.NEXT_PUBLIC_CLERK_SIGN_UP_URL,
+    NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: !!env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL,
+    NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: !!env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL,
   };
 
   // Check DB connectivity
@@ -32,8 +34,7 @@ export async function GET() {
     dbLatency = Date.now() - start;
     dbConnected = true;
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    console.error("DB health check error:", error);
     dbConnected = false;
   }
 
@@ -53,7 +54,7 @@ export async function GET() {
       label: "Anthropic AI",
     },
     vercel: {
-      configured: !!process.env.VERCEL,
+      configured: !!env.VERCEL,
       label: "Vercel Deployment",
     },
   };

--- a/app/src/app/api/attendance/route.ts
+++ b/app/src/app/api/attendance/route.ts
@@ -4,24 +4,22 @@ import { getAttendanceByUser, createAttendance } from "@/lib/queries/attendance"
 import { getUserByClerkId } from "@/lib/queries/users";
 import { hasAnyRole } from "@/lib/auth";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createAttendanceSchema } from "@/lib/validations";
 
 export async function GET(req: NextRequest) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   try {
     const targetUserId = req.nextUrl.searchParams.get("userId");
     const dbUser = await getUserByClerkId(userId);
-
     if (targetUserId && targetUserId !== dbUser?.id) {
       const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin", "board_member"]);
       if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       const records = await getAttendanceByUser(targetUserId);
       return NextResponse.json(records);
     }
-
     if (!dbUser) return NextResponse.json([]);
-
     const records = await getAttendanceByUser(dbUser.id);
     return NextResponse.json(records);
   } catch (err) {
@@ -33,39 +31,33 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   try {
     const dbUser = await getUserByClerkId(userId);
     if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
     const body = await req.json();
-
-    // Validate date format and not in future
-    if (!body.date || !/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
-      return NextResponse.json({ error: "Invalid date format. Use YYYY-MM-DD." }, { status: 400 });
-    }
+    const validated = validate(body, createAttendanceSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const today = new Date().toISOString().split("T")[0];
-    if (body.date > today) {
+    if (data.date > today) {
       return NextResponse.json({ error: "Cannot record attendance for a future date." }, { status: 400 });
     }
-
     const record = await createAttendance({
       id: generateId(),
       userId: dbUser.id,
-      date: body.date,
-      type: body.type || "regular",
-      makeupClub: body.makeupClub || null,
-      notes: body.notes || "",
+      date: data.date,
+      type: data.type,
+      makeupClub: data.makeupClub ?? null,
+      notes: data.notes,
       recordedBy: dbUser.id,
     });
-
     return NextResponse.json(record, { status: 201 });
   } catch (err) {
     console.error("POST /api/attendance error:", err);
-    // Handle unique constraint violation (already recorded for this date+type)
-    const message = err instanceof Error && err.message.includes("unique")
-      ? "Attendance already recorded for this date and type"
-      : "Failed to record attendance";
+    const message =
+      err instanceof Error && err.message.includes("unique")
+        ? "Attendance already recorded for this date and type"
+        : "Failed to record attendance";
     return NextResponse.json({ error: message }, { status: 400 });
   }
 }

--- a/app/src/app/api/board/action-items/[id]/route.ts
+++ b/app/src/app/api/board/action-items/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { updateBoardActionItem, deleteBoardActionItem } from "@/lib/queries/board";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await req.json();
+    const item = await updateBoardActionItem(id, body);
+    if (!item) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(item);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to update action item" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    await deleteBoardActionItem(id);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to delete action item" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/action-items/route.ts
+++ b/app/src/app/api/board/action-items/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllBoardActionItems, createBoardActionItem } from "@/lib/queries/board";
+import { generateId } from "@/lib/utils";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getAllBoardActionItems());
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to fetch action items" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const item = await createBoardActionItem({ id: generateId(), ...body });
+    return NextResponse.json(item, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to create action item" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/documents/[id]/route.ts
+++ b/app/src/app/api/board/documents/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { updateBoardDocument, deleteBoardDocument } from "@/lib/queries/board";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await req.json();
+    const doc = await updateBoardDocument(id, body);
+    if (!doc) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(doc);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to update document" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    await deleteBoardDocument(id);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to delete document" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/documents/route.ts
+++ b/app/src/app/api/board/documents/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllBoardDocuments, createBoardDocument } from "@/lib/queries/board";
+import { generateId } from "@/lib/utils";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getAllBoardDocuments());
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to fetch documents" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const doc = await createBoardDocument({ id: generateId(), ...body });
+    return NextResponse.json(doc, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to create document" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/meetings/[id]/route.ts
+++ b/app/src/app/api/board/meetings/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getBoardMeetingById, updateBoardMeeting, deleteBoardMeeting } from "@/lib/queries/board";
+
+export async function GET(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const meeting = await getBoardMeetingById(id);
+    if (!meeting) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(meeting);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to fetch meeting" }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await req.json();
+    const meeting = await updateBoardMeeting(id, body);
+    if (!meeting) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(meeting);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to update meeting" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    await deleteBoardMeeting(id);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to delete meeting" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/meetings/route.ts
+++ b/app/src/app/api/board/meetings/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllBoardMeetings, createBoardMeeting } from "@/lib/queries/board";
+import { generateId } from "@/lib/utils";
+
+export async function GET() {
+  try {
+    const meetings = await getAllBoardMeetings();
+    return NextResponse.json(meetings);
+  } catch (err) {
+    console.error("GET /api/board/meetings error:", err);
+    return NextResponse.json({ error: "Failed to fetch board meetings" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const meeting = await createBoardMeeting({ id: generateId(), ...body });
+    return NextResponse.json(meeting, { status: 201 });
+  } catch (err) {
+    console.error("POST /api/board/meetings error:", err);
+    return NextResponse.json({ error: "Failed to create board meeting" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/officer-terms/[id]/route.ts
+++ b/app/src/app/api/board/officer-terms/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { updateOfficerTerm, deleteOfficerTerm } from "@/lib/queries/board";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await req.json();
+    const term = await updateOfficerTerm(id, body);
+    if (!term) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(term);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to update officer term" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    await deleteOfficerTerm(id);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to delete officer term" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/officer-terms/route.ts
+++ b/app/src/app/api/board/officer-terms/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllOfficerTerms, createOfficerTerm } from "@/lib/queries/board";
+import { generateId } from "@/lib/utils";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getAllOfficerTerms());
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to fetch officer terms" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const term = await createOfficerTerm({ id: generateId(), ...body });
+    return NextResponse.json(term, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to create officer term" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/resolutions/[id]/route.ts
+++ b/app/src/app/api/board/resolutions/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getResolutionById, updateResolution, deleteResolution } from "@/lib/queries/board";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const body = await req.json();
+    const res = await updateResolution(id, body);
+    if (!res) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(res);
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to update resolution" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    await deleteResolution(id);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to delete resolution" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/board/resolutions/route.ts
+++ b/app/src/app/api/board/resolutions/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllResolutions, createResolution } from "@/lib/queries/board";
+import { generateId } from "@/lib/utils";
+
+export async function GET() {
+  try {
+    return NextResponse.json(await getAllResolutions());
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to fetch resolutions" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const resolution = await createResolution({ id: generateId(), ...body });
+    return NextResponse.json(resolution, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Failed to create resolution" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/bryn/threads/route.ts
+++ b/app/src/app/api/bryn/threads/route.ts
@@ -3,14 +3,14 @@ import { auth } from "@clerk/nextjs/server";
 import { getUserByClerkId } from "@/lib/queries/users";
 import { getThreadsByUser, createThread } from "@/lib/queries/chat";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createThreadSchema } from "@/lib/validations";
 
 export async function GET() {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const dbUser = await getUserByClerkId(userId);
   if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
   const threads = await getThreadsByUser(dbUser.id);
   return NextResponse.json(threads);
 }
@@ -18,18 +18,16 @@ export async function GET() {
 export async function POST(req: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const dbUser = await getUserByClerkId(userId);
   if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
   const body = await req.json().catch(() => ({}));
-  const title = (body as { title?: string }).title ?? "New conversation";
-
+  const validated = validate(body, createThreadSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
   const thread = await createThread({
     id: generateId(),
     userId: dbUser.id,
-    title,
+    title: data.title,
   });
-
   return NextResponse.json(thread, { status: 201 });
 }

--- a/app/src/app/api/budget/[id]/route.ts
+++ b/app/src/app/api/budget/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getBudgetItemById, updateBudgetItem, deleteBudgetItem } from "@/lib/queries/budget";
+import { validate } from "@/lib/validations/api-validate";
+import { updateBudgetItemSchema } from "@/lib/validations";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -17,7 +19,10 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   try {
     const { id } = await params;
     const body = await req.json();
-    const item = await updateBudgetItem(id, body);
+    const validated = validate(body, updateBudgetItemSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const item = await updateBudgetItem(id, data);
     if (!item) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(item);
   } catch (err) {

--- a/app/src/app/api/budget/route.ts
+++ b/app/src/app/api/budget/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllBudgetItems, createBudgetItem } from "@/lib/queries/budget";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createBudgetItemSchema } from "@/lib/validations";
 
 export async function GET() {
   try {
@@ -15,10 +17,10 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const item = await createBudgetItem({
-      ...body,
-      id: body.id || generateId(),
-    });
+    const validated = validate(body, createBudgetItemSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const item = await createBudgetItem({ ...data, id: generateId() });
     return NextResponse.json(item, { status: 201 });
   } catch (err) {
     console.error("POST /api/budget error:", err);

--- a/app/src/app/api/checkin/route.ts
+++ b/app/src/app/api/checkin/route.ts
@@ -5,22 +5,20 @@ import { getActiveSession, getExistingCheckin } from "@/lib/queries/checkin";
 import { createAttendance } from "@/lib/queries/attendance";
 import { getAllMembers, getUserByClerkId } from "@/lib/queries/users";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { checkinSchema } from "@/lib/validations";
 
 const CHECKIN_ROLES = ["super_admin", "club_admin", "board_member", "checkin_operator"] as const;
 
-// GET — member fuzzy search (Clerk-auth'd)
 export async function GET(request: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const allowed = await hasAnyRole(userId, [...CHECKIN_ROLES]);
   if (!allowed) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { searchParams } = new URL(request.url);
   const query = searchParams.get("q") ?? "";
-
   const session = await getActiveSession();
   if (!session) return NextResponse.json({ error: "No active session" }, { status: 404 });
-
   const members = await getAllMembers();
   const q = query.toLowerCase().trim();
   const filtered =
@@ -44,37 +42,30 @@ export async function GET(request: Request) {
             classification: m.classification,
             company: m.company,
           }));
-
   return NextResponse.json({ members: filtered, sessionDate: session.meetingDate });
 }
 
-// POST — record check-in (Clerk-auth'd)
 export async function POST(request: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const allowed = await hasAnyRole(userId, [...CHECKIN_ROLES]);
   if (!allowed) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const session = await getActiveSession();
   if (!session) return NextResponse.json({ error: "No active session" }, { status: 404 });
-
   const body = await request.json();
-  const { memberId } = body;
-  if (!memberId) return NextResponse.json({ error: "memberId required" }, { status: 400 });
-
-  const existing = await getExistingCheckin(memberId, session.meetingDate);
+  const validated = validate(body, checkinSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
+  const existing = await getExistingCheckin(data.memberId, session.meetingDate);
   if (existing) return NextResponse.json({ success: true, alreadyCheckedIn: true });
-
   const dbUser = await getUserByClerkId(userId).catch(() => null);
-
   await createAttendance({
     id: generateId(),
-    userId: memberId,
+    userId: data.memberId,
     date: session.meetingDate,
     type: "regular",
     notes: "Kiosk check-in",
     recordedBy: dbUser?.id ?? undefined,
   });
-
   return NextResponse.json({ success: true, alreadyCheckedIn: false });
 }

--- a/app/src/app/api/checkin/session/route.ts
+++ b/app/src/app/api/checkin/session/route.ts
@@ -4,39 +4,34 @@ import { hasAnyRole } from "@/lib/auth";
 import { getActiveSession, createSession } from "@/lib/queries/checkin";
 import { getUserByClerkId } from "@/lib/queries/users";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createCheckinSessionSchema } from "@/lib/validations";
 
-// GET — public, returns active session (without PIN for security)
 export async function GET() {
   const session = await getActiveSession();
   if (!session) return NextResponse.json({ session: null });
-  // Never expose PIN to the kiosk GET endpoint
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { pin: _pin, ...safe } = session;
   return NextResponse.json({ session: safe });
 }
 
-// POST — checkin-authorized roles only, opens a new session
 export async function POST(request: Request) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const allowed = await hasAnyRole(userId, ["super_admin", "club_admin", "board_member", "checkin_operator"]);
   if (!allowed) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const body = await request.json();
-  const { meetingDate, pin, notes } = body;
-  if (!meetingDate || !pin) return NextResponse.json({ error: "meetingDate and pin required" }, { status: 400 });
-
-  // Look up DB user to satisfy FK — null if not yet seeded
+  const validated = validate(body, createCheckinSessionSchema);
+  if (validated instanceof NextResponse) return validated;
+  const { data } = validated;
   const dbUser = await getUserByClerkId(userId).catch(() => null);
-
   const session = await createSession({
     id: generateId(),
-    meetingDate,
-    pin: String(pin),
+    meetingDate: data.meetingDate,
+    pin: data.pin,
     openedBy: dbUser?.id ?? null,
-    notes: notes ?? "",
+    notes: data.notes,
     isActive: true,
   });
-
   return NextResponse.json({ session });
 }

--- a/app/src/app/api/contacts/[id]/route.ts
+++ b/app/src/app/api/contacts/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getContactById, updateContact, deleteContact } from "@/lib/queries/contacts";
+import { validate } from "@/lib/validations/api-validate";
+import { updateContactSchema } from "@/lib/validations";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -17,7 +19,10 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   try {
     const { id } = await params;
     const body = await req.json();
-    const contact = await updateContact(id, body);
+    const validated = validate(body, updateContactSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const contact = await updateContact(id, data);
     if (!contact) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(contact);
   } catch (err) {

--- a/app/src/app/api/contacts/route.ts
+++ b/app/src/app/api/contacts/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllContacts, getContactsByType, createContact } from "@/lib/queries/contacts";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createContactSchema } from "@/lib/validations";
 
 export async function GET(req: NextRequest) {
   try {
     const type = req.nextUrl.searchParams.get("type");
     const publicOnly = req.nextUrl.searchParams.get("public") === "true";
-
     let contacts;
     if (type) {
       const types = type.split(",");
@@ -19,7 +20,6 @@ export async function GET(req: NextRequest) {
     } else {
       contacts = await getAllContacts();
     }
-
     return NextResponse.json(contacts);
   } catch (err) {
     console.error("GET /api/contacts error:", err);
@@ -30,14 +30,10 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const contact = await createContact({
-      ...body,
-      id: body.id || generateId(),
-      activities: body.activities || [],
-      tags: body.tags || [],
-      years: body.years || [],
-      publicVisible: body.publicVisible ?? false,
-    });
+    const validated = validate(body, createContactSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const contact = await createContact({ ...data, id: generateId() });
     return NextResponse.json(contact, { status: 201 });
   } catch (err) {
     console.error("POST /api/contacts error:", err);

--- a/app/src/app/api/event-config/route.ts
+++ b/app/src/app/api/event-config/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getEventConfig, updateEventConfig } from "@/lib/queries/event-config";
+import { validate } from "@/lib/validations/api-validate";
+import { updateEventConfigSchema } from "@/lib/validations";
 
 export async function GET() {
   try {
@@ -14,7 +16,10 @@ export async function GET() {
 export async function PUT(req: NextRequest) {
   try {
     const body = await req.json();
-    const config = await updateEventConfig(body);
+    const validated = validate(body, updateEventConfigSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const config = await updateEventConfig(data);
     return NextResponse.json(config);
   } catch (err) {
     console.error("PUT /api/event-config error:", err);

--- a/app/src/app/api/events-club/[id]/route.ts
+++ b/app/src/app/api/events-club/[id]/route.ts
@@ -7,14 +7,12 @@ import {
   getRsvpCountForEvent,
 } from "@/lib/queries/events-club";
 import { hasAnyRole } from "@/lib/auth";
+import { validate } from "@/lib/validations/api-validate";
+import { updateEventSchema } from "@/lib/validations";
 
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const { id } = await params;
   try {
     const event = await getClubEventById(id);
@@ -27,20 +25,18 @@ export async function GET(
   }
 }
 
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   try {
     const body = await req.json();
-    const updated = await updateClubEvent(id, { ...body, updatedAt: new Date() });
+    const validated = validate(body, updateEventSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const updated = await updateClubEvent(id, { ...data, updatedAt: new Date() });
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(updated);
   } catch (err) {
@@ -49,16 +45,11 @@ export async function PUT(
   }
 }
 
-export async function DELETE(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   try {
     await deleteClubEvent(id);

--- a/app/src/app/api/events-club/[id]/rsvp/route.ts
+++ b/app/src/app/api/events-club/[id]/rsvp/route.ts
@@ -3,32 +3,30 @@ import { auth } from "@clerk/nextjs/server";
 import { createRsvp, deleteRsvp, getRsvp } from "@/lib/queries/events-club";
 import { getUserByClerkId } from "@/lib/queries/users";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { rsvpSchema } from "@/lib/validations";
 
-export async function POST(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const { id: eventId } = await params;
   try {
     const dbUser = await getUserByClerkId(userId);
     if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
     const existing = await getRsvp(eventId, dbUser.id);
     if (existing) return NextResponse.json(existing);
-
-    const body = await _req.json().catch(() => ({}));
-
+    const body = await req.json().catch(() => ({}));
+    const validated = validate(body, rsvpSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const rsvp = await createRsvp({
       id: generateId(),
       eventId,
       userId: dbUser.id,
       status: "attending",
-      mealChoice: body.mealChoice || null,
-      guestCount: body.guestCount || 0,
-      guestNames: body.guestNames || null,
+      mealChoice: data.mealChoice ?? null,
+      guestCount: data.guestCount,
+      guestNames: data.guestNames ?? null,
     });
     return NextResponse.json(rsvp, { status: 201 });
   } catch (err) {
@@ -37,18 +35,13 @@ export async function POST(
   }
 }
 
-export async function DELETE(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const { id: eventId } = await params;
   try {
     const dbUser = await getUserByClerkId(userId);
     if (!dbUser) return NextResponse.json({ error: "User not found" }, { status: 404 });
-
     await deleteRsvp(eventId, dbUser.id);
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/app/src/app/api/events-club/route.ts
+++ b/app/src/app/api/events-club/route.ts
@@ -8,16 +8,16 @@ import {
 } from "@/lib/queries/events-club";
 import { getUserByClerkId } from "@/lib/queries/users";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createEventSchema } from "@/lib/validations";
 
 export async function GET(req: NextRequest) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   try {
     const status = req.nextUrl.searchParams.get("status");
     const upcoming = req.nextUrl.searchParams.get("upcoming") === "true";
     const mine = req.nextUrl.searchParams.get("mine") === "true";
-
     let events;
     if (upcoming) {
       events = await getUpcomingClubEvents();
@@ -32,7 +32,6 @@ export async function GET(req: NextRequest) {
     } else {
       events = await getAllClubEvents();
     }
-
     return NextResponse.json(events);
   } catch (err) {
     console.error("GET /api/events-club error:", err);
@@ -43,36 +42,21 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   try {
     const dbUser = await getUserByClerkId(userId);
     const body = await req.json();
-
-    if (!body.title?.trim()) {
-      return NextResponse.json({ error: "Event title is required." }, { status: 400 });
-    }
-    if (!body.date || !/^\d{4}-\d{2}-\d{2}$/.test(body.date)) {
-      return NextResponse.json({ error: "Invalid date format. Use YYYY-MM-DD." }, { status: 400 });
-    }
-
+    const validated = validate(body, createEventSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const event = await createClubEvent({
       id: generateId(),
-      title: body.title,
-      description: body.description || "",
-      date: body.date,
-      startTime: body.startTime || "",
-      endTime: body.endTime || "",
-      location: body.location || "",
-      category: body.category || "general",
-      rsvpUrl: body.rsvpUrl || "",
-      isPublic: body.isPublic ?? false,
+      ...data,
       status: "pending",
       submittedBy: dbUser?.id ?? null,
       approvedBy: null,
       slug: null,
       imageUrl: null,
     });
-
     return NextResponse.json(event, { status: 201 });
   } catch (err) {
     console.error("POST /api/events-club error:", err);

--- a/app/src/app/api/integrations/constant-contact/auth/route.ts
+++ b/app/src/app/api/integrations/constant-contact/auth/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { getAuthorizationUrl } from "@/lib/integrations/constant-contact";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const state = Math.random().toString(36).slice(2);
+  const url = getAuthorizationUrl(state);
+  return NextResponse.redirect(url);
+}

--- a/app/src/app/api/integrations/constant-contact/callback/route.ts
+++ b/app/src/app/api/integrations/constant-contact/callback/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { exchangeCodeForTokens } from "@/lib/integrations/constant-contact";
+import { db } from "@/lib/db/client";
+import { ccConfig } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function GET(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.redirect(new URL("/admin/integrations?error=unauthorized", req.url));
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.redirect(new URL("/admin/integrations?error=forbidden", req.url));
+
+  const code = req.nextUrl.searchParams.get("code");
+  if (!code) return NextResponse.redirect(new URL("/admin/integrations?error=no_code", req.url));
+
+  try {
+    const tokens = await exchangeCodeForTokens(code);
+    const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
+    const existing = await db.select().from(ccConfig).where(eq(ccConfig.id, 1));
+    if (existing.length > 0) {
+      await db.update(ccConfig).set({
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        tokenExpiresAt: expiresAt,
+        connected: true,
+        updatedAt: new Date(),
+      }).where(eq(ccConfig.id, 1));
+    } else {
+      await db.insert(ccConfig).values({
+        id: 1,
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        tokenExpiresAt: expiresAt,
+        connected: true,
+        syncSchedule: "manual",
+        fieldMappings: "{}",
+        updatedAt: new Date(),
+      });
+    }
+    return NextResponse.redirect(new URL("/admin/integrations?connected=true", req.url));
+  } catch (err) {
+    console.error("CC OAuth callback error:", err);
+    return NextResponse.redirect(new URL("/admin/integrations?error=token_exchange", req.url));
+  }
+}

--- a/app/src/app/api/integrations/constant-contact/disconnect/route.ts
+++ b/app/src/app/api/integrations/constant-contact/disconnect/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { db } from "@/lib/db/client";
+import { ccConfig } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function POST() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  await db.update(ccConfig).set({
+    accessToken: null,
+    refreshToken: null,
+    tokenExpiresAt: null,
+    connected: false,
+    updatedAt: new Date(),
+  }).where(eq(ccConfig.id, 1));
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/src/app/api/integrations/constant-contact/lists/route.ts
+++ b/app/src/app/api/integrations/constant-contact/lists/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { getLists } from "@/lib/integrations/constant-contact";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  try {
+    const lists = await getLists();
+    return NextResponse.json(lists);
+  } catch (err) {
+    console.error("CC lists error:", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Failed" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/integrations/constant-contact/logs/route.ts
+++ b/app/src/app/api/integrations/constant-contact/logs/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { db } from "@/lib/db/client";
+import { ccSyncLogs } from "@/lib/db/schema";
+import { desc } from "drizzle-orm";
+
+export async function GET(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const limit = parseInt(req.nextUrl.searchParams.get("limit") ?? "50");
+  const logs = await db.select().from(ccSyncLogs).orderBy(desc(ccSyncLogs.createdAt)).limit(limit);
+  return NextResponse.json(logs);
+}

--- a/app/src/app/api/integrations/constant-contact/mappings/route.ts
+++ b/app/src/app/api/integrations/constant-contact/mappings/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { db } from "@/lib/db/client";
+import { ccListMappings } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { generateId } from "@/lib/utils";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const mappings = await db.select().from(ccListMappings);
+  return NextResponse.json(mappings);
+}
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json();
+  const { segment, ccListId, ccListName } = body;
+  if (!segment) return NextResponse.json({ error: "segment required" }, { status: 400 });
+
+  const existing = await db.select().from(ccListMappings).where(eq(ccListMappings.segment, segment));
+  if (existing.length > 0) {
+    const updated = await db.update(ccListMappings).set({
+      ccListId: ccListId ?? "",
+      ccListName: ccListName ?? "",
+      enabled: body.enabled ?? true,
+      updatedAt: new Date(),
+    }).where(eq(ccListMappings.segment, segment)).returning();
+    return NextResponse.json(updated[0]);
+  } else {
+    const created = await db.insert(ccListMappings).values({
+      id: generateId(),
+      segment,
+      ccListId: ccListId ?? "",
+      ccListName: ccListName ?? "",
+      enabled: body.enabled ?? true,
+      updatedAt: new Date(),
+    }).returning();
+    return NextResponse.json(created[0], { status: 201 });
+  }
+}

--- a/app/src/app/api/integrations/constant-contact/schedule/route.ts
+++ b/app/src/app/api/integrations/constant-contact/schedule/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { db } from "@/lib/db/client";
+import { ccConfig } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json();
+  const { syncSchedule } = body;
+  if (!["manual", "nightly", "weekly"].includes(syncSchedule)) {
+    return NextResponse.json({ error: "Invalid schedule" }, { status: 400 });
+  }
+
+  const existing = await db.select().from(ccConfig).where(eq(ccConfig.id, 1));
+  if (existing.length > 0) {
+    await db.update(ccConfig).set({ syncSchedule, updatedAt: new Date() }).where(eq(ccConfig.id, 1));
+  } else {
+    await db.insert(ccConfig).values({ id: 1, syncSchedule, fieldMappings: "{}", updatedAt: new Date() });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/src/app/api/integrations/constant-contact/status/route.ts
+++ b/app/src/app/api/integrations/constant-contact/status/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { db } from "@/lib/db/client";
+import { ccConfig, ccListMappings } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const rows = await db.select().from(ccConfig).where(eq(ccConfig.id, 1));
+  const config = rows[0] ?? { connected: false, syncSchedule: "manual", fieldMappings: "{}" };
+  const mappings = await db.select().from(ccListMappings);
+
+  return NextResponse.json({
+    connected: config.connected ?? false,
+    syncSchedule: config.syncSchedule ?? "manual",
+    fieldMappings: JSON.parse((config as { fieldMappings?: string }).fieldMappings ?? "{}"),
+    mappings,
+  });
+}

--- a/app/src/app/api/integrations/constant-contact/sync/route.ts
+++ b/app/src/app/api/integrations/constant-contact/sync/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { hasAnyRole } from "@/lib/auth";
+import { syncSegment, ALL_SEGMENTS, Segment } from "@/lib/integrations/constant-contact";
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
+  if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const body = await req.json().catch(() => ({}));
+  const segment = body.segment as Segment | "all" | undefined;
+
+  try {
+    if (!segment || segment === "all") {
+      const results: Record<string, { synced: number; failed: number; error?: string }> = {};
+      for (const seg of ALL_SEGMENTS) {
+        results[seg] = await syncSegment(seg, "manual");
+      }
+      return NextResponse.json({ ok: true, results });
+    } else {
+      const result = await syncSegment(segment, "manual");
+      return NextResponse.json({ ok: true, result });
+    }
+  } catch (err) {
+    console.error("CC sync error:", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "Sync failed" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/meetings/[id]/route.ts
+++ b/app/src/app/api/meetings/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getMeetingById, updateMeeting, deleteMeeting } from "@/lib/queries/meetings";
+import { validate } from "@/lib/validations/api-validate";
+import { updateMeetingSchema } from "@/lib/validations";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -17,7 +19,10 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   try {
     const { id } = await params;
     const body = await req.json();
-    const meeting = await updateMeeting(id, body);
+    const validated = validate(body, updateMeetingSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const meeting = await updateMeeting(id, data);
     if (!meeting) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(meeting);
   } catch (err) {

--- a/app/src/app/api/meetings/route.ts
+++ b/app/src/app/api/meetings/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllMeetings, createMeeting } from "@/lib/queries/meetings";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createMeetingSchema } from "@/lib/validations";
 
 export async function GET() {
   try {
@@ -15,12 +17,10 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const meeting = await createMeeting({
-      ...body,
-      id: body.id || generateId(),
-      attendees: body.attendees || [],
-      actionItems: body.actionItems || [],
-    });
+    const validated = validate(body, createMeetingSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const meeting = await createMeeting({ ...data, id: generateId() });
     return NextResponse.json(meeting, { status: 201 });
   } catch (err) {
     console.error("POST /api/meetings error:", err);

--- a/app/src/app/api/members/[id]/route.ts
+++ b/app/src/app/api/members/[id]/route.ts
@@ -1,16 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { getUserById, updateUser, deleteUser } from "@/lib/queries/users";
-import { getUserByClerkId } from "@/lib/queries/users";
+import { getUserById, updateUser, deleteUser, getUserByClerkId } from "@/lib/queries/users";
 import { hasAnyRole } from "@/lib/auth";
+import { validate } from "@/lib/validations/api-validate";
+import { updateMemberSchema } from "@/lib/validations";
 
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const { id } = await params;
   try {
     const member = await getUserById(id);
@@ -22,33 +19,27 @@ export async function GET(
   }
 }
 
-export async function PUT(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const { id } = await params;
-
-  // Allow updating own profile or if admin
   const dbUser = await getUserByClerkId(userId);
   const isOwnProfile = dbUser?.id === id;
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
-
-  if (!isOwnProfile && !isAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
+  if (!isOwnProfile && !isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const body = await req.json();
-    // Prevent non-admins from changing roles or member type
     if (!isAdmin) {
       delete body.roles;
       delete body.memberType;
       delete body.status;
     }
-    const updated = await updateUser(id, { ...body, updatedAt: new Date() });
+    const validated = validate(body, updateMemberSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const updateData: Record<string, unknown> = { ...data, updatedAt: new Date() };
+    if (Array.isArray(data.roles)) updateData.roles = JSON.stringify(data.roles);
+    const updated = await updateUser(id, updateData);
     if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(updated);
   } catch (err) {
@@ -57,16 +48,11 @@ export async function PUT(
   }
 }
 
-export async function DELETE(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   const { id } = await params;
   try {
     await deleteUser(id);

--- a/app/src/app/api/members/route.ts
+++ b/app/src/app/api/members/route.ts
@@ -3,21 +3,17 @@ import { auth } from "@clerk/nextjs/server";
 import { getAllMembers, createUser } from "@/lib/queries/users";
 import { hasAnyRole } from "@/lib/auth";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createMemberSchema } from "@/lib/validations";
 
 export async function GET(req: NextRequest) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   try {
     const search = req.nextUrl.searchParams.get("search")?.toLowerCase();
     const memberType = req.nextUrl.searchParams.get("memberType");
-
     let members = await getAllMembers();
-
-    if (memberType) {
-      members = members.filter((m) => m.memberType === memberType);
-    }
-
+    if (memberType) members = members.filter((m) => m.memberType === memberType);
     if (search) {
       members = members.filter(
         (m) =>
@@ -27,7 +23,6 @@ export async function GET(req: NextRequest) {
           m.email.toLowerCase().includes(search)
       );
     }
-
     return NextResponse.json(members);
   } catch (err) {
     console.error("GET /api/members error:", err);
@@ -38,16 +33,18 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const { userId } = await auth();
   if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
   if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
   try {
     const body = await req.json();
+    const validated = validate(body, createMemberSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const user = await createUser({
-      ...body,
-      id: body.id || generateId(),
-      clerkId: body.clerkId || generateId(),
+      ...data,
+      id: generateId(),
+      clerkId: data.clerkId ?? generateId(),
+      roles: JSON.stringify(data.roles),
     });
     return NextResponse.json(user, { status: 201 });
   } catch (err) {

--- a/app/src/app/api/membership-inquiries/route.ts
+++ b/app/src/app/api/membership-inquiries/route.ts
@@ -1,68 +1,45 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import {
-  getAllInquiries,
-  createInquiry,
-} from "@/lib/queries/membership-inquiries";
+import { getAllInquiries, createInquiry } from "@/lib/queries/membership-inquiries";
 import { hasAnyRole } from "@/lib/auth";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createInquirySchema } from "@/lib/validations";
 
-// GET /api/membership-inquiries — admin only
 export async function GET() {
   try {
     const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
+    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin"]);
-    if (!isAdmin) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
+    if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     const inquiries = await getAllInquiries();
     return NextResponse.json(inquiries);
   } catch (error) {
     console.error("Error fetching inquiries:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch inquiries" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch inquiries" }, { status: 500 });
   }
 }
 
-// POST /api/membership-inquiries — public
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { name, email, phone, company, classification, reason, referredBy } =
-      body;
-
-    if (!name || !email) {
-      return NextResponse.json(
-        { error: "Name and email are required" },
-        { status: 400 }
-      );
-    }
-
+    const validated = validate(body, createInquirySchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const inquiry = await createInquiry({
       id: generateId(),
-      name,
-      email,
-      phone: phone || "",
-      company: company || "",
-      classification: classification || "",
-      reason: reason || "",
-      referredBy: referredBy || "",
+      name: data.name,
+      email: data.email,
+      phone: data.phone,
+      company: data.company,
+      classification: data.classification,
+      reason: data.reason,
+      referredBy: data.referredBy,
       status: "new",
     });
-
     return NextResponse.json(inquiry, { status: 201 });
   } catch (error) {
     console.error("Error creating inquiry:", error);
-    return NextResponse.json(
-      { error: "Failed to submit inquiry" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to submit inquiry" }, { status: 500 });
   }
 }

--- a/app/src/app/api/membership-pipeline/[id]/activities/route.ts
+++ b/app/src/app/api/membership-pipeline/[id]/activities/route.ts
@@ -1,78 +1,50 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
-import {
-  getActivitiesForProspect,
-  createProspectActivity,
-} from "@/lib/queries/membership-pipeline";
+import { getActivitiesForProspect, createProspectActivity } from "@/lib/queries/membership-pipeline";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createProspectActivitySchema } from "@/lib/validations";
 
-export async function GET(
-  _req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
-  if (!userId)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const canView = await hasAnyRole(userId, [
-    "super_admin",
-    "club_admin",
-    "board_member",
-  ]);
-  if (!canView)
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const canView = await hasAnyRole(userId, ["super_admin", "club_admin", "board_member"]);
+  if (!canView) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const { id } = await params;
     const activities = await getActivitiesForProspect(id);
     return NextResponse.json(activities);
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json([], { status: 200 });
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
-export async function POST(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
-  if (!userId)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const canEdit = await hasAnyRole(userId, ["super_admin", "club_admin"]);
-  if (!canEdit)
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
+  if (!canEdit) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const { id } = await params;
     const body = await req.json();
-
-    if (!body.activityType)
-      return NextResponse.json(
-        { error: "Activity type required" },
-        { status: 400 }
-      );
-
+    const validated = validate(body, createProspectActivitySchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const activity = await createProspectActivity({
       id: generateId(),
       prospectId: id,
-      activityType: body.activityType,
-      fromStage: body.fromStage ?? null,
-      toStage: body.toStage ?? null,
-      description: body.description ?? "",
-      activityDate: body.activityDate ? new Date(body.activityDate) : new Date(),
+      activityType: data.activityType,
+      fromStage: data.fromStage ?? null,
+      toStage: data.toStage ?? null,
+      description: data.description,
+      activityDate: data.activityDate ? new Date(data.activityDate) : new Date(),
       loggedBy: userId,
     });
-
     return NextResponse.json(activity, { status: 201 });
   } catch (err) {
     console.error("Create activity error:", err);
-    return NextResponse.json(
-      { error: "Failed to create activity" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to create activity" }, { status: 500 });
   }
 }

--- a/app/src/app/api/membership-pipeline/[id]/route.ts
+++ b/app/src/app/api/membership-pipeline/[id]/route.ts
@@ -2,119 +2,73 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import {
-  getProspectById,
-  updateProspect,
-  deleteProspect,
-  createProspectActivity,
+  getProspectById, updateProspect, deleteProspect, createProspectActivity,
 } from "@/lib/queries/membership-pipeline";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { updateProspectSchema } from "@/lib/validations";
 
-export async function GET(
-  _req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
-  if (!userId)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const canView = await hasAnyRole(userId, [
-    "super_admin",
-    "club_admin",
-    "board_member",
-  ]);
-  if (!canView)
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const canView = await hasAnyRole(userId, ["super_admin", "club_admin", "board_member"]);
+  if (!canView) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const { id } = await params;
     const prospect = await getProspectById(id);
-    if (!prospect)
-      return NextResponse.json(
-        { error: "Prospect not found" },
-        { status: 404 }
-      );
-
+    if (!prospect) return NextResponse.json({ error: "Prospect not found" }, { status: 404 });
     return NextResponse.json(prospect);
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json(
-      { error: "Failed to fetch prospect" },
-      { status: 500 }
-    );
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
-export async function PATCH(
-  req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
-  if (!userId)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const canEdit = await hasAnyRole(userId, ["super_admin", "club_admin"]);
-  if (!canEdit)
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
+  if (!canEdit) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const { id } = await params;
     const existing = await getProspectById(id);
-    if (!existing)
-      return NextResponse.json(
-        { error: "Prospect not found" },
-        { status: 404 }
-      );
-
+    if (!existing) return NextResponse.json({ error: "Prospect not found" }, { status: 404 });
     const body = await req.json();
-
-    // Track stage change
-    if (body.stage && body.stage !== existing.stage) {
+    const validated = validate(body, updateProspectSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const updateData: Record<string, unknown> = { ...data };
+    if (data.stage && data.stage !== existing.stage) {
       await createProspectActivity({
         id: generateId(),
         prospectId: id,
         activityType: "stage_change",
         fromStage: existing.stage,
-        toStage: body.stage,
-        description: `Stage changed from ${existing.stage} to ${body.stage}`,
+        toStage: data.stage,
+        description: `Stage changed from ${existing.stage} to ${data.stage}`,
         loggedBy: userId,
       });
-      body.stageUpdatedAt = new Date();
+      updateData.stageUpdatedAt = new Date();
     }
-
-    const updated = await updateProspect(id, body);
+    const updated = await updateProspect(id, updateData);
     return NextResponse.json(updated);
   } catch (err) {
     console.error("Update prospect error:", err);
-    return NextResponse.json(
-      { error: "Failed to update prospect" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to update prospect" }, { status: 500 });
   }
 }
 
-export async function DELETE(
-  _req: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
   const { userId } = await auth();
-  if (!userId)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const canEdit = await hasAnyRole(userId, ["super_admin", "club_admin"]);
-  if (!canEdit)
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
+  if (!canEdit) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const { id } = await params;
     await deleteProspect(id);
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json(
-      { error: "Failed to delete prospect" },
-      { status: 500 }
-    );
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/app/src/app/api/membership-pipeline/route.ts
+++ b/app/src/app/api/membership-pipeline/route.ts
@@ -8,77 +8,55 @@ import {
   createProspectActivity,
 } from "@/lib/queries/membership-pipeline";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createProspectSchema } from "@/lib/validations";
 
 export async function GET(req: Request) {
   const { userId } = await auth();
-  if (!userId)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const canView = await hasAnyRole(userId, [
-    "super_admin",
-    "club_admin",
-    "board_member",
-  ]);
-  if (!canView)
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const canView = await hasAnyRole(userId, ["super_admin", "club_admin", "board_member"]);
+  if (!canView) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const { searchParams } = new URL(req.url);
     const search = searchParams.get("search");
-
-    const prospects = search
-      ? await searchProspects(search)
-      : await getAllProspects();
-
+    const prospects = search ? await searchProspects(search) : await getAllProspects();
     return NextResponse.json(prospects);
   } catch (error) {
-    console.error('API error:', error);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
-    return NextResponse.json([], { status: 200 });
+    console.error("API error:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
 
 export async function POST(req: Request) {
   const { userId } = await auth();
-  if (!userId)
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const canEdit = await hasAnyRole(userId, ["super_admin", "club_admin"]);
-  if (!canEdit)
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
+  if (!canEdit) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try {
     const body = await req.json();
-    const { firstName, lastName } = body;
-
-    if (!firstName || !lastName)
-      return NextResponse.json(
-        { error: "First and last name required" },
-        { status: 400 }
-      );
-
+    const validated = validate(body, createProspectSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const id = generateId();
     const prospect = await createProspect({
       id,
-      firstName,
-      lastName,
-      email: body.email ?? "",
-      phone: body.phone ?? "",
-      company: body.company ?? "",
-      classification: body.classification ?? "",
-      source: body.source ?? "web_inquiry",
-      referredBy: body.referredBy ?? null,
-      sponsorId: body.sponsorId ?? null,
-      stage: body.stage ?? "identified",
-      nextAction: body.nextAction ?? "",
-      nextActionDue: body.nextActionDue ?? null,
-      sourceInquiryId: body.sourceInquiryId ?? null,
-      sourceContactId: body.sourceContactId ?? null,
-      notes: body.notes ?? "",
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email,
+      phone: data.phone,
+      company: data.company,
+      classification: data.classification,
+      source: data.source,
+      referredBy: data.referredBy ?? null,
+      sponsorId: data.sponsorId ?? null,
+      stage: data.stage,
+      nextAction: data.nextAction,
+      nextActionDue: data.nextActionDue ?? null,
+      sourceInquiryId: data.sourceInquiryId ?? null,
+      sourceContactId: data.sourceContactId ?? null,
+      notes: data.notes,
       createdBy: userId,
     });
-
-    // Log initial activity
     await createProspectActivity({
       id: generateId(),
       prospectId: id,
@@ -88,13 +66,9 @@ export async function POST(req: Request) {
       description: "Prospect created",
       loggedBy: userId,
     });
-
     return NextResponse.json(prospect, { status: 201 });
   } catch (err) {
     console.error("Create prospect error:", err);
-    return NextResponse.json(
-      { error: "Failed to create prospect" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to create prospect" }, { status: 500 });
   }
 }

--- a/app/src/app/api/pages/[slug]/route.ts
+++ b/app/src/app/api/pages/[slug]/route.ts
@@ -1,136 +1,73 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import {
-  getPageBySlug,
-  updatePage,
-  deletePage,
-  createPageVersion,
-} from "@/lib/queries/pages";
+import { getPageBySlug, updatePage, deletePage, createPageVersion } from "@/lib/queries/pages";
 import { hasAnyRole } from "@/lib/auth";
+import { validate } from "@/lib/validations/api-validate";
+import { updatePageSchema } from "@/lib/validations";
 
 type RouteParams = { params: Promise<{ slug: string }> };
 
-// GET /api/pages/[slug] — public (published only) or admin (any)
 export async function GET(_request: Request, { params }: RouteParams) {
   try {
     const { slug } = await params;
     const page = await getPageBySlug(slug);
-
-    if (!page) {
-      return NextResponse.json({ error: "Page not found" }, { status: 404 });
-    }
-
-    // If not published, require admin
+    if (!page) return NextResponse.json({ error: "Page not found" }, { status: 404 });
     if (!page.published) {
       const { userId } = await auth();
-      if (!userId) {
-        return NextResponse.json(
-          { error: "Page not found" },
-          { status: 404 }
-        );
-      }
-      const isAdmin = await hasAnyRole(userId, [
-        "super_admin",
-        "club_admin",
-        "website_admin",
-      ]);
-      if (!isAdmin) {
-        return NextResponse.json(
-          { error: "Page not found" },
-          { status: 404 }
-        );
-      }
+      if (!userId) return NextResponse.json({ error: "Page not found" }, { status: 404 });
+      const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin", "website_admin"]);
+      if (!isAdmin) return NextResponse.json({ error: "Page not found" }, { status: 404 });
     }
-
     return NextResponse.json(page);
   } catch (error) {
     console.error("Error fetching page:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch page" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch page" }, { status: 500 });
   }
 }
 
-// PUT /api/pages/[slug] — admin only, creates version before updating
 export async function PUT(request: Request, { params }: RouteParams) {
   try {
     const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const isAdmin = await hasAnyRole(userId, [
-      "super_admin",
-      "club_admin",
-      "website_admin",
-    ]);
-    if (!isAdmin) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
+    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin", "website_admin"]);
+    if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     const { slug } = await params;
     const page = await getPageBySlug(slug);
-    if (!page) {
-      return NextResponse.json({ error: "Page not found" }, { status: 404 });
-    }
-
+    if (!page) return NextResponse.json({ error: "Page not found" }, { status: 404 });
     const body = await request.json();
-
-    // Save current version before updating
+    const validated = validate(body, updatePageSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     await createPageVersion(page.id, page.content, page.version, userId);
-
-    const newVersion = page.version + 1;
     const updated = await updatePage(page.id, {
-      title: body.title ?? page.title,
-      content: body.content ?? page.content,
-      metaDescription: body.metaDescription ?? page.metaDescription,
-      published: body.published ?? page.published,
+      title: data.title ?? page.title,
+      content: data.content ?? page.content,
+      metaDescription: data.metaDescription ?? page.metaDescription,
+      published: data.published ?? page.published,
       updatedBy: userId,
-      version: newVersion,
+      version: page.version + 1,
       updatedAt: new Date(),
     });
-
     return NextResponse.json(updated);
   } catch (error) {
     console.error("Error updating page:", error);
-    return NextResponse.json(
-      { error: "Failed to update page" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to update page" }, { status: 500 });
   }
 }
 
-// DELETE /api/pages/[slug] — admin only
 export async function DELETE(_request: Request, { params }: RouteParams) {
   try {
     const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const isAdmin = await hasAnyRole(userId, [
-      "super_admin",
-      "club_admin",
-      "website_admin",
-    ]);
-    if (!isAdmin) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
+    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin", "website_admin"]);
+    if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     const { slug } = await params;
     const page = await getPageBySlug(slug);
-    if (!page) {
-      return NextResponse.json({ error: "Page not found" }, { status: 404 });
-    }
-
+    if (!page) return NextResponse.json({ error: "Page not found" }, { status: 404 });
     await deletePage(page.id);
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error("Error deleting page:", error);
-    return NextResponse.json(
-      { error: "Failed to delete page" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to delete page" }, { status: 500 });
   }
 }

--- a/app/src/app/api/pages/route.ts
+++ b/app/src/app/api/pages/route.ts
@@ -3,81 +3,48 @@ import { auth } from "@clerk/nextjs/server";
 import { getAllPages, createPage } from "@/lib/queries/pages";
 import { hasAnyRole } from "@/lib/auth";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createPageSchema } from "@/lib/validations";
 
-// GET /api/pages — public: returns published pages; admin: returns all
 export async function GET() {
   try {
     const allPages = await getAllPages();
-
-    // Check if user is admin — if so, return all pages
     const { userId } = await auth();
     if (userId) {
-      const isAdmin = await hasAnyRole(userId, [
-        "super_admin",
-        "club_admin",
-        "website_admin",
-      ]);
-      if (isAdmin) {
-        return NextResponse.json(allPages);
-      }
+      const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin", "website_admin"]);
+      if (isAdmin) return NextResponse.json(allPages);
     }
-
-    // Public: only published pages
     const published = allPages.filter((p) => p.published);
     return NextResponse.json(published);
   } catch (error) {
     console.error("Error fetching pages:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch pages" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to fetch pages" }, { status: 500 });
   }
 }
 
-// POST /api/pages — admin only
 export async function POST(request: Request) {
   try {
     const { userId } = await auth();
-    if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const isAdmin = await hasAnyRole(userId, [
-      "super_admin",
-      "club_admin",
-      "website_admin",
-    ]);
-    if (!isAdmin) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
+    if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const isAdmin = await hasAnyRole(userId, ["super_admin", "club_admin", "website_admin"]);
+    if (!isAdmin) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     const body = await request.json();
-    const { slug, title, content, metaDescription, published } = body;
-
-    if (!slug || !title) {
-      return NextResponse.json(
-        { error: "Slug and title are required" },
-        { status: 400 }
-      );
-    }
-
+    const validated = validate(body, createPageSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const page = await createPage({
       id: generateId(),
-      slug,
-      title,
-      content: content || "",
-      metaDescription: metaDescription || "",
-      published: published !== false,
+      slug: data.slug,
+      title: data.title,
+      content: data.content,
+      metaDescription: data.metaDescription,
+      published: data.published,
       updatedBy: userId,
       version: 1,
     });
-
     return NextResponse.json(page, { status: 201 });
   } catch (error) {
     console.error("Error creating page:", error);
-    return NextResponse.json(
-      { error: "Failed to create page" },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: "Failed to create page" }, { status: 500 });
   }
 }

--- a/app/src/app/api/public/contact/route.ts
+++ b/app/src/app/api/public/contact/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createContact } from "@/lib/queries/contacts";
+import { generateId } from "@/lib/utils";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, email, subject, message } = await req.json();
+
+    if (!name || !email || !message) {
+      return NextResponse.json({ error: "Name, email, and message are required" }, { status: 400 });
+    }
+
+    await createContact({
+      id: generateId(),
+      name,
+      email,
+      company: "",
+      phone: "",
+      type: "potential_sponsor",
+      status: "lead",
+      website: "",
+      address: "",
+      notes: `Subject: ${subject || "General"}\n\n${message}`,
+      activities: [],
+      tags: ["website-inquiry"],
+      years: [],
+      assignedTo: "",
+      publicVisible: false,
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("POST /api/public/contact error:", err);
+    return NextResponse.json({ error: "Failed to submit" }, { status: 500 });
+  }
+}

--- a/app/src/app/api/tasks/[id]/route.ts
+++ b/app/src/app/api/tasks/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTaskById, updateTask, deleteTask } from "@/lib/queries/tasks";
+import { validate } from "@/lib/validations/api-validate";
+import { updateTaskSchema } from "@/lib/validations";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -17,7 +19,10 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   try {
     const { id } = await params;
     const body = await req.json();
-    const task = await updateTask(id, body);
+    const validated = validate(body, updateTaskSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const task = await updateTask(id, data);
     if (!task) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(task);
   } catch (err) {

--- a/app/src/app/api/tasks/route.ts
+++ b/app/src/app/api/tasks/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllTasks, createTask } from "@/lib/queries/tasks";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createTaskSchema } from "@/lib/validations";
 
 export async function GET() {
   try {
@@ -15,10 +17,10 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const task = await createTask({
-      ...body,
-      id: body.id || generateId(),
-    });
+    const validated = validate(body, createTaskSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
+    const task = await createTask({ ...data, id: generateId() });
     return NextResponse.json(task, { status: 201 });
   } catch (err) {
     console.error("POST /api/tasks error:", err);

--- a/app/src/app/api/vendor-interest/[id]/route.ts
+++ b/app/src/app/api/vendor-interest/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSubmissionById, processSubmission } from "@/lib/queries/vendor-interest";
 import { createContact } from "@/lib/queries/contacts";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { processVendorInterestSchema } from "@/lib/validations";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -15,22 +17,18 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   }
 }
 
-// PUT converts submission into a contact lead
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const body = await req.json();
-
+    const validated = validate(body, processVendorInterestSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const submission = await getSubmissionById(id);
     if (!submission) return NextResponse.json({ error: "Not found" }, { status: 404 });
-
-    if (submission.processed) {
-      return NextResponse.json({ error: "Already processed" }, { status: 400 });
-    }
-
+    if (submission.processed) return NextResponse.json({ error: "Already processed" }, { status: 400 });
     const currentYear = new Date().getFullYear();
     const contactId = generateId();
-
     await createContact({
       id: contactId,
       name: submission.contactName || submission.businessName,
@@ -50,7 +48,7 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
           type: "note",
           description: `Converted from vendor interest form submission. Previous participant: ${submission.previousParticipant ? "Yes" : "No"}`,
           date: new Date().toISOString(),
-          createdBy: body.convertedBy || "Admin",
+          createdBy: data.convertedBy,
         },
       ],
       tags: ["vendor-interest-form"],
@@ -58,7 +56,6 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
       assignedTo: "Unassigned",
       publicVisible: false,
     });
-
     const updated = await processSubmission(id, contactId);
     return NextResponse.json(updated);
   } catch (err) {

--- a/app/src/app/api/vendor-interest/route.ts
+++ b/app/src/app/api/vendor-interest/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllSubmissions, createSubmission } from "@/lib/queries/vendor-interest";
 import { generateId } from "@/lib/utils";
+import { validate } from "@/lib/validations/api-validate";
+import { createVendorInterestSchema } from "@/lib/validations";
 
 export async function GET() {
   try {
@@ -15,23 +17,20 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-
-    if (!body.businessName) {
-      return NextResponse.json({ error: "Business name is required" }, { status: 400 });
-    }
-
+    const validated = validate(body, createVendorInterestSchema);
+    if (validated instanceof NextResponse) return validated;
+    const { data } = validated;
     const submission = await createSubmission({
       id: generateId(),
-      businessName: body.businessName,
-      contactName: body.contactName || "",
-      email: body.email || "",
-      phone: body.phone || "",
-      category: body.category || "",
-      website: body.website || "",
-      description: body.description || "",
-      previousParticipant: body.previousParticipant ?? false,
+      businessName: data.businessName,
+      contactName: data.contactName,
+      email: data.email,
+      phone: data.phone,
+      category: data.category,
+      website: data.website,
+      description: data.description,
+      previousParticipant: data.previousParticipant,
     });
-
     return NextResponse.json(submission, { status: 201 });
   } catch (err) {
     console.error("POST /api/vendor-interest error:", err);

--- a/app/src/components/layout/admin-sidebar.tsx
+++ b/app/src/components/layout/admin-sidebar.tsx
@@ -32,6 +32,7 @@ const navItems = [
   { href: "/admin/announcements", label: "Announcements", icon: Megaphone },
   { href: "/admin/website", label: "Website (CMS)", icon: Globe },
   { href: "/admin/reports", label: "Reports", icon: BarChart3 },
+  { href: "/admin/integrations", label: "Integrations", icon: Settings },
   { href: "/admin/settings", label: "Settings", icon: Settings },
   { href: "/uncorked-hub", label: "Planning Hub", icon: Compass },
 ];

--- a/app/src/lib/db/schema.ts
+++ b/app/src/lib/db/schema.ts
@@ -392,3 +392,43 @@ export const checkinSessions = pgTable("checkin_sessions", {
   isActive: boolean("is_active").notNull().default(true),
   notes: varchar("notes", { length: 512 }).notNull().default(""),
 });
+
+// ============================================
+// cc_list_mappings — Constant Contact segment → list mapping
+// ============================================
+export const ccListMappings = pgTable("cc_list_mappings", {
+  id: varchar("id", { length: 128 }).primaryKey(),
+  segment: varchar("segment", { length: 64 }).notNull().unique(),
+  ccListId: varchar("cc_list_id", { length: 256 }).notNull().default(""),
+  ccListName: varchar("cc_list_name", { length: 256 }).notNull().default(""),
+  enabled: boolean("enabled").notNull().default(true),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+// ============================================
+// cc_sync_logs — Constant Contact sync history
+// ============================================
+export const ccSyncLogs = pgTable("cc_sync_logs", {
+  id: varchar("id", { length: 128 }).primaryKey(),
+  segment: varchar("segment", { length: 64 }).notNull(),
+  status: varchar("status", { length: 32 }).notNull(),
+  recordsSynced: integer("records_synced").notNull().default(0),
+  recordsFailed: integer("records_failed").notNull().default(0),
+  errorMessage: text("error_message"),
+  triggeredBy: varchar("triggered_by", { length: 32 }).notNull().default("manual"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+// ============================================
+// cc_config — single-row OAuth + schedule config
+// ============================================
+export const ccConfig = pgTable("cc_config", {
+  id: integer("id").primaryKey().default(1),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  tokenExpiresAt: timestamp("token_expires_at"),
+  connected: boolean("connected").notNull().default(false),
+  syncSchedule: varchar("sync_schedule", { length: 32 }).notNull().default("manual"),
+  fieldMappings: text("field_mappings").notNull().default("{}"),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});

--- a/app/src/lib/env.ts
+++ b/app/src/lib/env.ts
@@ -1,0 +1,136 @@
+/**
+ * env.ts — Environment variable validation
+ *
+ * All environment variables are validated here at module load time.
+ * If any required variable is missing or malformed, the app will throw
+ * immediately with a clear error message rather than failing mysteriously
+ * at runtime.
+ *
+ * Usage:
+ *   import { env } from "@/lib/env";
+ *   env.DATABASE_URL   // server-side
+ *   env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY  // client-safe
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Server-side schema (never sent to the browser)
+// ---------------------------------------------------------------------------
+const serverSchema = z.object({
+  DATABASE_URL: z
+    .string()
+    .min(1, "DATABASE_URL is required")
+    .refine((v) => v.startsWith("postgres"), {
+      message: "DATABASE_URL must be a PostgreSQL connection string",
+    }),
+
+  CLERK_SECRET_KEY: z
+    .string()
+    .min(1, "CLERK_SECRET_KEY is required")
+    .refine((v) => v.startsWith("sk_"), {
+      message: "CLERK_SECRET_KEY must start with 'sk_'",
+    }),
+
+  ANTHROPIC_API_KEY: z
+    .string()
+    .min(1, "ANTHROPIC_API_KEY is required")
+    .refine((v) => v.startsWith("sk-ant-"), {
+      message: "ANTHROPIC_API_KEY must start with 'sk-ant-'",
+    }),
+
+  // Optional server-side vars
+  SLACK_BOT_TOKEN: z.string().optional(),
+  SLACK_APP_TOKEN: z.string().optional(),
+  CLICKUP_API_TOKEN: z.string().optional(),
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
+  GOOGLE_REFRESH_TOKEN: z.string().optional(),
+  VERCEL: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Client-safe schema (NEXT_PUBLIC_* vars — available in browser too)
+// ---------------------------------------------------------------------------
+const clientSchema = z.object({
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z
+    .string()
+    .min(1, "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is required")
+    .refine((v) => v.startsWith("pk_"), {
+      message: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY must start with 'pk_'",
+    }),
+
+  NEXT_PUBLIC_CLERK_SIGN_IN_URL: z.string().min(1).default("/login"),
+  NEXT_PUBLIC_CLERK_SIGN_UP_URL: z.string().min(1).default("/register"),
+  NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: z.string().min(1).default("/portal"),
+  NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: z.string().min(1).default("/portal"),
+
+  // Optional client vars
+  NEXT_PUBLIC_APP_URL: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Validation helper — formats Zod errors into readable messages
+// ---------------------------------------------------------------------------
+function formatErrors(errors: z.ZodError): string {
+  return errors.issues
+    .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
+    .join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Validate and export
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate server-side environment variables.
+ * Called only on the server — throws at startup if anything is missing.
+ */
+function validateServer(): z.infer<typeof serverSchema> {
+  const result = serverSchema.safeParse(process.env);
+  if (!result.success) {
+    throw new Error(
+      `\n\u274C Invalid server environment variables:\n${formatErrors(result.error)}\n` +
+        `\nCheck your .env.local file against .env.template.\n`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Validate client-safe environment variables.
+ * Safe to call on both server and client.
+ */
+function validateClient(): z.infer<typeof clientSchema> {
+  const result = clientSchema.safeParse(process.env);
+  if (!result.success) {
+    throw new Error(
+      `\n\u274C Invalid client environment variables:\n${formatErrors(result.error)}\n` +
+        `\nCheck your .env.local file against .env.template.\n`,
+    );
+  }
+  return result.data;
+}
+
+// On the server: validate everything. On the client: validate client vars only.
+const isServer = typeof window === "undefined";
+
+const clientEnv = validateClient();
+const serverEnv = isServer ? validateServer() : ({} as z.infer<typeof serverSchema>);
+
+/**
+ * Fully-typed, validated environment variables.
+ *
+ * Server-side vars (DATABASE_URL, CLERK_SECRET_KEY, etc.) are only
+ * populated on the server and will be empty objects on the client.
+ *
+ * Use env.NEXT_PUBLIC_* for anything you need in client components.
+ */
+export const env = {
+  ...clientEnv,
+  ...serverEnv,
+} as z.infer<typeof clientSchema> & z.infer<typeof serverSchema>;
+
+// Re-export types for convenience
+export type ServerEnv = z.infer<typeof serverSchema>;
+export type ClientEnv = z.infer<typeof clientSchema>;

--- a/app/src/lib/integrations/constant-contact.ts
+++ b/app/src/lib/integrations/constant-contact.ts
@@ -1,0 +1,213 @@
+/**
+ * Constant Contact API Client
+ * OAuth 2.0 + contact/list management
+ */
+
+import { db } from "@/lib/db/client";
+import { ccConfig, ccListMappings, ccSyncLogs, users } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { generateId } from "@/lib/utils";
+
+const CC_BASE_URL = "https://api.cc.email/v3";
+const CC_AUTH_URL = "https://authz.constantcontact.com/oauth2/default/v1/authorize";
+const CC_TOKEN_URL = "https://authz.constantcontact.com/oauth2/default/v1/token";
+
+export interface CCContact {
+  email_address: { address: string; permission_to_send?: string };
+  first_name?: string;
+  last_name?: string;
+  phone_numbers?: Array<{ phone_number: string; kind: string }>;
+  company_name?: string;
+  list_memberships?: string[];
+}
+
+export interface CCList {
+  list_id: string;
+  name: string;
+  membership_count?: number;
+}
+
+export function getAuthorizationUrl(state: string): string {
+  const params = new URLSearchParams({
+    client_id: process.env.CONSTANT_CONTACT_CLIENT_ID ?? "",
+    redirect_uri: process.env.CONSTANT_CONTACT_REDIRECT_URI ?? "",
+    response_type: "code",
+    scope: "contact_data list_data",
+    state,
+  });
+  return `${CC_AUTH_URL}?${params.toString()}`;
+}
+
+export async function exchangeCodeForTokens(code: string) {
+  const clientId = process.env.CONSTANT_CONTACT_CLIENT_ID ?? "";
+  const clientSecret = process.env.CONSTANT_CONTACT_CLIENT_SECRET ?? "";
+  const redirectUri = process.env.CONSTANT_CONTACT_REDIRECT_URI ?? "";
+  const body = new URLSearchParams({ grant_type: "authorization_code", code, redirect_uri: redirectUri });
+  const res = await fetch(CC_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+    },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error(`Token exchange failed: ${await res.text()}`);
+  return res.json() as Promise<{ access_token: string; refresh_token: string; expires_in: number }>;
+}
+
+export async function refreshAccessToken(refreshToken: string) {
+  const clientId = process.env.CONSTANT_CONTACT_CLIENT_ID ?? "";
+  const clientSecret = process.env.CONSTANT_CONTACT_CLIENT_SECRET ?? "";
+  const body = new URLSearchParams({ grant_type: "refresh_token", refresh_token: refreshToken });
+  const res = await fetch(CC_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+    },
+    body: body.toString(),
+  });
+  if (!res.ok) throw new Error("Failed to refresh token");
+  return res.json() as Promise<{ access_token: string; refresh_token: string; expires_in: number }>;
+}
+
+export async function getValidAccessToken(): Promise<string> {
+  const rows = await db.select().from(ccConfig).where(eq(ccConfig.id, 1));
+  const config = rows[0];
+  if (!config?.accessToken) throw new Error("Not connected to Constant Contact");
+  const now = new Date();
+  const expiresAt = config.tokenExpiresAt ? new Date(config.tokenExpiresAt) : new Date(0);
+  if (config.refreshToken && expiresAt.getTime() - now.getTime() < 5 * 60 * 1000) {
+    const tokens = await refreshAccessToken(config.refreshToken);
+    const newExpiry = new Date(Date.now() + tokens.expires_in * 1000);
+    await db.update(ccConfig).set({
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      tokenExpiresAt: newExpiry,
+      updatedAt: new Date(),
+    }).where(eq(ccConfig.id, 1));
+    return tokens.access_token;
+  }
+  return config.accessToken;
+}
+
+async function ccFetch(path: string, opts: RequestInit = {}): Promise<Response> {
+  const token = await getValidAccessToken();
+  return fetch(`${CC_BASE_URL}${path}`, {
+    ...opts,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...(opts.headers ?? {}),
+    },
+  });
+}
+
+export async function getLists(): Promise<CCList[]> {
+  const res = await ccFetch("/contact_lists?include_count=true&limit=50");
+  if (!res.ok) throw new Error(`Failed to fetch lists: ${await res.text()}`);
+  const data = await res.json();
+  return data.lists ?? [];
+}
+
+export async function createList(name: string): Promise<CCList> {
+  const res = await ccFetch("/contact_lists", { method: "POST", body: JSON.stringify({ name, favorite: false }) });
+  if (!res.ok) throw new Error(`Failed to create list: ${await res.text()}`);
+  return res.json();
+}
+
+export async function upsertContact(contact: CCContact): Promise<string> {
+  const res = await ccFetch("/contacts/sign_up_form", { method: "POST", body: JSON.stringify(contact) });
+  if (!res.ok) throw new Error(`Failed to upsert contact: ${await res.text()}`);
+  const data = await res.json();
+  return data.contact_id ?? "";
+}
+
+export type Segment = "all_members" | "board" | "external_community" | "potential_members" | "full_list";
+
+export const SEGMENT_LABELS: Record<Segment, string> = {
+  all_members: "All Members",
+  board: "Board",
+  external_community: "External / Community",
+  potential_members: "Potential Members",
+  full_list: "Full List",
+};
+
+export const ALL_SEGMENTS: Segment[] = [
+  "all_members",
+  "board",
+  "external_community",
+  "potential_members",
+  "full_list",
+];
+
+export async function getMembersForSegment(segment: Segment) {
+  const allMembers = await db.select().from(users);
+  switch (segment) {
+    case "all_members":
+      return allMembers.filter((u) => u.status === "active");
+    case "board": {
+      return allMembers.filter((u) => {
+        const roles = JSON.parse(u.roles || "[]") as string[];
+        return roles.some((r) =>
+          ["president", "vice_president", "secretary", "treasurer", "board_member", "club_admin", "super_admin"].includes(r)
+        );
+      });
+    }
+    case "external_community":
+      return allMembers.filter((u) => u.memberType === "honorary" || u.memberType === "alumni");
+    case "potential_members":
+      return allMembers.filter((u) => u.memberType === "prospect" || u.memberType === "leave");
+    case "full_list":
+      return allMembers;
+    default:
+      return [];
+  }
+}
+
+export async function syncSegment(
+  segment: Segment,
+  triggeredBy: "manual" | "nightly" | "weekly" = "manual"
+): Promise<{ synced: number; failed: number; error?: string }> {
+  const logId = generateId();
+  let synced = 0;
+  let failed = 0;
+  let errorMessage: string | undefined;
+
+  try {
+    const rows = await db.select().from(ccListMappings).where(eq(ccListMappings.segment, segment));
+    const mapping = rows[0];
+    if (!mapping?.ccListId) throw new Error(`No CC list mapped for segment: ${segment}`);
+    const members = await getMembersForSegment(segment);
+    for (const member of members) {
+      try {
+        await upsertContact({
+          email_address: { address: member.email, permission_to_send: "implicit" },
+          first_name: member.firstName || undefined,
+          last_name: member.lastName || undefined,
+          phone_numbers: member.phone ? [{ phone_number: member.phone, kind: "home" }] : undefined,
+          company_name: member.company || undefined,
+          list_memberships: [mapping.ccListId],
+        });
+        synced++;
+      } catch {
+        failed++;
+      }
+    }
+  } catch (err) {
+    errorMessage = err instanceof Error ? err.message : "Unknown error";
+  }
+
+  await db.insert(ccSyncLogs).values({
+    id: logId,
+    segment,
+    status: errorMessage ? "failed" : failed > 0 ? "partial" : "success",
+    recordsSynced: synced,
+    recordsFailed: failed,
+    errorMessage: errorMessage ?? null,
+    triggeredBy,
+    createdAt: new Date(),
+  });
+
+  return { synced, failed, error: errorMessage };
+}

--- a/app/src/lib/queries/board.ts
+++ b/app/src/lib/queries/board.ts
@@ -1,0 +1,172 @@
+import { eq, desc, asc } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import {
+  boardMeetings,
+  boardResolutions,
+  boardDocuments,
+  boardActionItems,
+  officerTerms,
+} from "@/lib/db/schema";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type BoardMeeting = typeof boardMeetings.$inferSelect;
+export type BoardResolution = typeof boardResolutions.$inferSelect;
+export type BoardDocument = typeof boardDocuments.$inferSelect;
+export type BoardActionItem = typeof boardActionItems.$inferSelect;
+export type OfficerTerm = typeof officerTerms.$inferSelect;
+
+// ── Board Meetings ─────────────────────────────────────────────────────────
+
+export async function getAllBoardMeetings(): Promise<BoardMeeting[]> {
+  return db.select().from(boardMeetings).orderBy(desc(boardMeetings.date));
+}
+
+export async function getBoardMeetingById(id: string): Promise<BoardMeeting | null> {
+  const [row] = await db.select().from(boardMeetings).where(eq(boardMeetings.id, id));
+  return row ?? null;
+}
+
+export async function createBoardMeeting(
+  data: Omit<typeof boardMeetings.$inferInsert, "createdAt" | "updatedAt">
+): Promise<BoardMeeting> {
+  const now = new Date();
+  await db.insert(boardMeetings).values({ ...data, createdAt: now, updatedAt: now });
+  return (await getBoardMeetingById(data.id))!;
+}
+
+export async function updateBoardMeeting(
+  id: string,
+  data: Partial<Omit<typeof boardMeetings.$inferInsert, "id" | "createdAt">>
+): Promise<BoardMeeting | null> {
+  await db.update(boardMeetings).set({ ...data, updatedAt: new Date() }).where(eq(boardMeetings.id, id));
+  return getBoardMeetingById(id);
+}
+
+export async function deleteBoardMeeting(id: string): Promise<void> {
+  await db.delete(boardMeetings).where(eq(boardMeetings.id, id));
+}
+
+// ── Resolutions ────────────────────────────────────────────────────────────
+
+export async function getAllResolutions(): Promise<BoardResolution[]> {
+  return db.select().from(boardResolutions).orderBy(desc(boardResolutions.date));
+}
+
+export async function getResolutionById(id: string): Promise<BoardResolution | null> {
+  const [row] = await db.select().from(boardResolutions).where(eq(boardResolutions.id, id));
+  return row ?? null;
+}
+
+export async function createResolution(
+  data: Omit<typeof boardResolutions.$inferInsert, "createdAt" | "updatedAt">
+): Promise<BoardResolution> {
+  const now = new Date();
+  await db.insert(boardResolutions).values({ ...data, createdAt: now, updatedAt: now });
+  return (await getResolutionById(data.id))!;
+}
+
+export async function updateResolution(
+  id: string,
+  data: Partial<Omit<typeof boardResolutions.$inferInsert, "id" | "createdAt">>
+): Promise<BoardResolution | null> {
+  await db.update(boardResolutions).set({ ...data, updatedAt: new Date() }).where(eq(boardResolutions.id, id));
+  return getResolutionById(id);
+}
+
+export async function deleteResolution(id: string): Promise<void> {
+  await db.delete(boardResolutions).where(eq(boardResolutions.id, id));
+}
+
+// ── Documents ──────────────────────────────────────────────────────────────
+
+export async function getAllBoardDocuments(): Promise<BoardDocument[]> {
+  return db.select().from(boardDocuments).orderBy(asc(boardDocuments.category), asc(boardDocuments.title));
+}
+
+export async function getBoardDocumentById(id: string): Promise<BoardDocument | null> {
+  const [row] = await db.select().from(boardDocuments).where(eq(boardDocuments.id, id));
+  return row ?? null;
+}
+
+export async function createBoardDocument(
+  data: Omit<typeof boardDocuments.$inferInsert, "createdAt" | "updatedAt">
+): Promise<BoardDocument> {
+  const now = new Date();
+  await db.insert(boardDocuments).values({ ...data, createdAt: now, updatedAt: now });
+  return (await getBoardDocumentById(data.id))!;
+}
+
+export async function updateBoardDocument(
+  id: string,
+  data: Partial<Omit<typeof boardDocuments.$inferInsert, "id" | "createdAt">>
+): Promise<BoardDocument | null> {
+  await db.update(boardDocuments).set({ ...data, updatedAt: new Date() }).where(eq(boardDocuments.id, id));
+  return getBoardDocumentById(id);
+}
+
+export async function deleteBoardDocument(id: string): Promise<void> {
+  await db.delete(boardDocuments).where(eq(boardDocuments.id, id));
+}
+
+// ── Action Items ───────────────────────────────────────────────────────────
+
+export async function getAllBoardActionItems(): Promise<BoardActionItem[]> {
+  return db.select().from(boardActionItems).orderBy(desc(boardActionItems.createdAt));
+}
+
+export async function getBoardActionItemById(id: string): Promise<BoardActionItem | null> {
+  const [row] = await db.select().from(boardActionItems).where(eq(boardActionItems.id, id));
+  return row ?? null;
+}
+
+export async function createBoardActionItem(
+  data: Omit<typeof boardActionItems.$inferInsert, "createdAt" | "updatedAt">
+): Promise<BoardActionItem> {
+  const now = new Date();
+  await db.insert(boardActionItems).values({ ...data, createdAt: now, updatedAt: now });
+  return (await getBoardActionItemById(data.id))!;
+}
+
+export async function updateBoardActionItem(
+  id: string,
+  data: Partial<Omit<typeof boardActionItems.$inferInsert, "id" | "createdAt">>
+): Promise<BoardActionItem | null> {
+  await db.update(boardActionItems).set({ ...data, updatedAt: new Date() }).where(eq(boardActionItems.id, id));
+  return getBoardActionItemById(id);
+}
+
+export async function deleteBoardActionItem(id: string): Promise<void> {
+  await db.delete(boardActionItems).where(eq(boardActionItems.id, id));
+}
+
+// ── Officer Terms ──────────────────────────────────────────────────────────
+
+export async function getAllOfficerTerms(): Promise<OfficerTerm[]> {
+  return db.select().from(officerTerms).orderBy(desc(officerTerms.startDate));
+}
+
+export async function getOfficerTermById(id: string): Promise<OfficerTerm | null> {
+  const [row] = await db.select().from(officerTerms).where(eq(officerTerms.id, id));
+  return row ?? null;
+}
+
+export async function createOfficerTerm(
+  data: Omit<typeof officerTerms.$inferInsert, "createdAt" | "updatedAt">
+): Promise<OfficerTerm> {
+  const now = new Date();
+  await db.insert(officerTerms).values({ ...data, createdAt: now, updatedAt: now });
+  return (await getOfficerTermById(data.id))!;
+}
+
+export async function updateOfficerTerm(
+  id: string,
+  data: Partial<Omit<typeof officerTerms.$inferInsert, "id" | "createdAt">>
+): Promise<OfficerTerm | null> {
+  await db.update(officerTerms).set({ ...data, updatedAt: new Date() }).where(eq(officerTerms.id, id));
+  return getOfficerTermById(id);
+}
+
+export async function deleteOfficerTerm(id: string): Promise<void> {
+  await db.delete(officerTerms).where(eq(officerTerms.id, id));
+}

--- a/app/src/lib/validations/announcements.ts
+++ b/app/src/lib/validations/announcements.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const ANNOUNCEMENT_CATEGORIES = ["general", "urgent", "event", "committee"] as const;
+const ANNOUNCEMENT_ACTIONS = ["publish", "unpublish"] as const;
+
+export const createAnnouncementSchema = z.object({
+  title: z.string().min(1, "Title is required").max(512),
+  content: z.string().min(1, "Content is required"),
+  category: z.enum(ANNOUNCEMENT_CATEGORIES).default("general"),
+  pinned: z.boolean().default(false),
+  publish: z.boolean().default(false),
+});
+
+export const updateAnnouncementSchema = z.object({
+  action: z.enum(ANNOUNCEMENT_ACTIONS).optional(),
+  title: z.string().min(1).max(512).optional(),
+  content: z.string().min(1).optional(),
+  category: z.enum(ANNOUNCEMENT_CATEGORIES).optional(),
+  pinned: z.boolean().optional(),
+  publish: z.boolean().optional(),
+});
+
+export type CreateAnnouncementInput = z.infer<typeof createAnnouncementSchema>;
+export type UpdateAnnouncementInput = z.infer<typeof updateAnnouncementSchema>;

--- a/app/src/lib/validations/api-validate.ts
+++ b/app/src/lib/validations/api-validate.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { NextResponse } from "next/server";
+
+/**
+ * Validates a parsed JSON body against a Zod schema.
+ * Returns { data } on success or a NextResponse 400 on failure.
+ */
+export function validate<T>(
+  body: unknown,
+  schema: z.ZodType<T>
+): { data: T } | NextResponse {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    return NextResponse.json(
+      {
+        error: "Validation failed",
+        issues: result.error.issues.map((i) => ({
+          path: i.path.join("."),
+          message: i.message,
+        })),
+      },
+      { status: 400 }
+    );
+  }
+  return { data: result.data };
+}

--- a/app/src/lib/validations/attendance.ts
+++ b/app/src/lib/validations/attendance.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { dateString } from "./common";
+
+const ATTENDANCE_TYPES = ["regular", "makeup", "online", "service"] as const;
+
+export const createAttendanceSchema = z.object({
+  date: dateString,
+  type: z.enum(ATTENDANCE_TYPES).default("regular"),
+  makeupClub: z.string().max(256).nullable().optional(),
+  notes: z.string().default(""),
+});
+
+export const bulkAttendanceSchema = z.object({
+  date: dateString,
+  attendees: z.array(z.string()).min(1, "At least one attendee is required"),
+  type: z.enum(ATTENDANCE_TYPES).default("regular"),
+});
+
+export type CreateAttendanceInput = z.infer<typeof createAttendanceSchema>;
+export type BulkAttendanceInput = z.infer<typeof bulkAttendanceSchema>;

--- a/app/src/lib/validations/bryn.ts
+++ b/app/src/lib/validations/bryn.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const brynChatSchema = z.object({
+  messages: z.array(z.unknown()).min(1, "At least one message is required"),
+  agentContext: z.enum(["member", "website", "operations", "uncorked"]).default("member"),
+  threadId: z.string().optional(),
+});
+
+export const createThreadSchema = z.object({
+  title: z.string().max(256).default("New conversation"),
+});
+
+export type BrynChatInput = z.infer<typeof brynChatSchema>;
+export type CreateThreadInput = z.infer<typeof createThreadSchema>;

--- a/app/src/lib/validations/budget.ts
+++ b/app/src/lib/validations/budget.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { dateString } from "./common";
+
+const BUDGET_TYPES = ["income", "expense"] as const;
+
+export const createBudgetItemSchema = z.object({
+  description: z.string().min(1, "Description is required").max(512),
+  category: z.string().min(1, "Category is required").max(32),
+  type: z.enum(BUDGET_TYPES),
+  amount: z.number().nonnegative().default(0),
+  budgeted: z.number().nonnegative().default(0),
+  date: dateString.or(z.literal("")).default(""),
+  notes: z.string().default(""),
+});
+
+export const updateBudgetItemSchema = createBudgetItemSchema.partial();
+
+export type CreateBudgetItemInput = z.infer<typeof createBudgetItemSchema>;
+export type UpdateBudgetItemInput = z.infer<typeof updateBudgetItemSchema>;

--- a/app/src/lib/validations/checkin.ts
+++ b/app/src/lib/validations/checkin.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { dateString } from "./common";
+
+export const createCheckinSessionSchema = z.object({
+  meetingDate: dateString,
+  pin: z
+    .string()
+    .min(4, "PIN must be at least 4 characters")
+    .max(8, "PIN must be at most 8 characters")
+    .regex(/^\d+$/, "PIN must be numeric"),
+  notes: z.string().default(""),
+});
+
+export const checkinSchema = z.object({
+  memberId: z.string().min(1, "memberId is required"),
+});
+
+export type CreateCheckinSessionInput = z.infer<typeof createCheckinSessionSchema>;
+export type CheckinInput = z.infer<typeof checkinSchema>;

--- a/app/src/lib/validations/committees.ts
+++ b/app/src/lib/validations/committees.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const COMMITTEE_CATEGORIES = ["standing", "special", "ad_hoc"] as const;
+const COMMITTEE_MEMBER_ROLES = ["chair", "co-chair", "member"] as const;
+const COMMITTEE_ACTIONS = ["add_member", "remove_member"] as const;
+
+export const createCommitteeSchema = z.object({
+  name: z.string().min(1, "Name is required").max(256),
+  description: z.string().default(""),
+  category: z.enum(COMMITTEE_CATEGORIES).default("standing"),
+  chairUserId: z.string().nullable().optional(),
+  active: z.boolean().default(true),
+});
+
+export const updateCommitteeSchema = z.object({
+  action: z.enum(COMMITTEE_ACTIONS).optional(),
+  userId: z.string().optional(),
+  role: z.enum(COMMITTEE_MEMBER_ROLES).optional(),
+  name: z.string().min(1).max(256).optional(),
+  description: z.string().optional(),
+  category: z.enum(COMMITTEE_CATEGORIES).optional(),
+  chairUserId: z.string().nullable().optional(),
+  active: z.boolean().optional(),
+});
+
+export type CreateCommitteeInput = z.infer<typeof createCommitteeSchema>;
+export type UpdateCommitteeInput = z.infer<typeof updateCommitteeSchema>;

--- a/app/src/lib/validations/common.ts
+++ b/app/src/lib/validations/common.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+/** YYYY-MM-DD date string */
+export const dateString = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format");
+
+/** HH:MM time string (or empty) */
+export const timeString = z
+  .string()
+  .regex(/^\d{1,2}:\d{2}$/, "Time must be in HH:MM format")
+  .or(z.literal(""));

--- a/app/src/lib/validations/contacts.ts
+++ b/app/src/lib/validations/contacts.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+const CONTACT_TYPES = [
+  "sponsor", "vendor", "potential_sponsor", "potential_vendor", "partner", "other",
+] as const;
+const PIPELINE_STATUSES = ["lead", "prospect", "active", "lapsed", "declined"] as const;
+const ACTIVITY_TYPES = [
+  "note", "call", "email", "meeting", "proposal", "contract", "renewal", "other",
+] as const;
+
+export const contactActivitySchema = z.object({
+  id: z.string().optional(),
+  type: z.enum(ACTIVITY_TYPES),
+  description: z.string().default(""),
+  date: z.string(),
+  createdBy: z.string().default(""),
+});
+
+export const createContactSchema = z.object({
+  name: z.string().min(1, "Name is required").max(256),
+  company: z.string().max(256).default(""),
+  email: z.string().email().or(z.literal("")).default(""),
+  phone: z.string().max(64).default(""),
+  type: z.enum(CONTACT_TYPES),
+  status: z.enum(PIPELINE_STATUSES).default("lead"),
+  tier: z.string().max(32).nullable().optional(),
+  vendorCategory: z.string().max(32).nullable().optional(),
+  website: z.string().url().or(z.literal("")).default(""),
+  address: z.string().max(512).default(""),
+  notes: z.string().default(""),
+  activities: z.array(contactActivitySchema).default([]),
+  tags: z.array(z.string()).default([]),
+  years: z.array(z.number().int()).default([]),
+  assignedTo: z.string().max(128).default("Unassigned"),
+  logoUrl: z.string().url().or(z.literal("")).nullable().optional(),
+  publicVisible: z.boolean().default(false),
+});
+
+export const updateContactSchema = createContactSchema.partial();
+
+export type CreateContactInput = z.infer<typeof createContactSchema>;
+export type UpdateContactInput = z.infer<typeof updateContactSchema>;

--- a/app/src/lib/validations/event-config.ts
+++ b/app/src/lib/validations/event-config.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { dateString } from "./common";
+
+export const updateEventConfigSchema = z.object({
+  eventName: z.string().max(256).optional(),
+  eventDate: dateString.optional(),
+  eventTime: z.string().max(32).optional(),
+  venue: z.string().max(256).optional(),
+  venueAddress: z.string().max(512).optional(),
+  ticketUrlGeneral: z.string().url().or(z.literal("")).optional(),
+  ticketUrlVip: z.string().url().or(z.literal("")).optional(),
+  priceGeneral: z.number().nonnegative().optional(),
+  priceVip: z.number().nonnegative().optional(),
+  heroImageUrl: z.string().url().or(z.literal("")).optional(),
+});
+
+export type UpdateEventConfigInput = z.infer<typeof updateEventConfigSchema>;

--- a/app/src/lib/validations/events.ts
+++ b/app/src/lib/validations/events.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { dateString, timeString } from "./common";
+
+const EVENT_CATEGORIES = ["meeting", "service", "social", "fundraiser", "speaker", "general"] as const;
+const EVENT_STATUSES = ["pending", "approved", "cancelled"] as const;
+
+export const createEventSchema = z.object({
+  title: z.string().min(1, "Event title is required").max(512),
+  description: z.string().max(5000).default(""),
+  date: dateString,
+  startTime: timeString.default(""),
+  endTime: timeString.default(""),
+  location: z.string().max(512).default(""),
+  category: z.enum(EVENT_CATEGORIES).default("general"),
+  rsvpUrl: z.string().url().or(z.literal("")).default(""),
+  isPublic: z.boolean().default(false),
+});
+
+export const updateEventSchema = z.object({
+  title: z.string().min(1).max(512).optional(),
+  description: z.string().max(5000).optional(),
+  date: dateString.optional(),
+  startTime: timeString.optional(),
+  endTime: timeString.optional(),
+  location: z.string().max(512).optional(),
+  category: z.enum(EVENT_CATEGORIES).optional(),
+  rsvpUrl: z.string().url().or(z.literal("")).optional(),
+  isPublic: z.boolean().optional(),
+  status: z.enum(EVENT_STATUSES).optional(),
+  slug: z.string().max(256).nullable().optional(),
+  imageUrl: z.string().url().or(z.literal("")).nullable().optional(),
+});
+
+export const adminUpdateEventSchema = updateEventSchema.extend({
+  action: z.enum(["approve", "reject"]).optional(),
+});
+
+export const rsvpSchema = z.object({
+  mealChoice: z.string().max(64).nullable().optional(),
+  guestCount: z.number().int().min(0).default(0),
+  guestNames: z.string().max(512).nullable().optional(),
+});
+
+export type CreateEventInput = z.infer<typeof createEventSchema>;
+export type UpdateEventInput = z.infer<typeof updateEventSchema>;
+export type AdminUpdateEventInput = z.infer<typeof adminUpdateEventSchema>;
+export type RsvpInput = z.infer<typeof rsvpSchema>;

--- a/app/src/lib/validations/index.ts
+++ b/app/src/lib/validations/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Central export for all Zod validation schemas.
+ * Import from "@/lib/validations" in API routes and client forms.
+ */
+
+export * from "./members";
+export * from "./events";
+export * from "./tasks";
+export * from "./meetings";
+export * from "./contacts";
+export * from "./budget";
+export * from "./announcements";
+export * from "./committees";
+export * from "./pages";
+export * from "./attendance";
+export * from "./checkin";
+export * from "./membership-inquiries";
+export * from "./membership-pipeline";
+export * from "./vendor-interest";
+export * from "./event-config";
+export * from "./bryn";
+export * from "./common";

--- a/app/src/lib/validations/meetings.ts
+++ b/app/src/lib/validations/meetings.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { dateString, timeString } from "./common";
+
+export const createMeetingSchema = z.object({
+  title: z.string().min(1, "Title is required").max(512),
+  date: dateString,
+  time: timeString.default(""),
+  attendees: z.array(z.string()).default([]),
+  notes: z.string().default(""),
+  category: z.string().max(32).default("general"),
+  actionItems: z
+    .array(
+      z.object({
+        id: z.string().optional(),
+        text: z.string().min(1),
+        assignee: z.string().default("Unassigned"),
+        completed: z.boolean().default(false),
+        dueDate: z.string().nullable().optional(),
+      })
+    )
+    .default([]),
+});
+
+export const updateMeetingSchema = createMeetingSchema.partial();
+
+export type CreateMeetingInput = z.infer<typeof createMeetingSchema>;
+export type UpdateMeetingInput = z.infer<typeof updateMeetingSchema>;

--- a/app/src/lib/validations/members.ts
+++ b/app/src/lib/validations/members.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const MEMBER_TYPES = ["active", "honorary", "alumni", "leave", "prospect"] as const;
+const MEMBER_STATUSES = ["active", "inactive", "suspended"] as const;
+
+export const createMemberSchema = z.object({
+  email: z.string().email("Valid email required"),
+  firstName: z.string().max(128).default(""),
+  lastName: z.string().max(128).default(""),
+  phone: z.string().max(64).default(""),
+  company: z.string().max(256).default(""),
+  classification: z.string().max(128).default(""),
+  memberType: z.enum(MEMBER_TYPES).default("active"),
+  roles: z.array(z.string()).default(["member"]),
+  clerkId: z.string().optional(),
+  bio: z.string().optional(),
+  address: z.string().max(512).optional(),
+  photoUrl: z.string().url().or(z.literal("")).optional(),
+});
+
+export const updateMemberSchema = z.object({
+  firstName: z.string().max(128).optional(),
+  lastName: z.string().max(128).optional(),
+  phone: z.string().max(64).optional(),
+  company: z.string().max(256).optional(),
+  classification: z.string().max(128).optional(),
+  memberType: z.enum(MEMBER_TYPES).optional(),
+  status: z.enum(MEMBER_STATUSES).optional(),
+  bio: z.string().optional(),
+  address: z.string().max(512).optional(),
+  photoUrl: z.string().url().or(z.literal("")).optional(),
+  roles: z.array(z.string()).optional(),
+});
+
+export const inviteMemberSchema = z.object({
+  email: z.string().email("Valid email required"),
+  firstName: z.string().max(128).default(""),
+  lastName: z.string().max(128).default(""),
+  roles: z.array(z.string()).default(["member"]),
+});
+
+export const importMembersSchema = z.object({
+  csvText: z.string().min(1, "CSV text required"),
+  preview: z.boolean().default(false),
+});
+
+export type CreateMemberInput = z.infer<typeof createMemberSchema>;
+export type UpdateMemberInput = z.infer<typeof updateMemberSchema>;
+export type InviteMemberInput = z.infer<typeof inviteMemberSchema>;
+export type ImportMembersInput = z.infer<typeof importMembersSchema>;

--- a/app/src/lib/validations/membership-inquiries.ts
+++ b/app/src/lib/validations/membership-inquiries.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const createInquirySchema = z.object({
+  name: z.string().min(1, "Name is required").max(256),
+  email: z.string().email("Valid email required"),
+  phone: z.string().max(64).default(""),
+  company: z.string().max(256).default(""),
+  classification: z.string().max(128).default(""),
+  reason: z.string().default(""),
+  referredBy: z.string().max(256).default(""),
+});
+
+export type CreateInquiryInput = z.infer<typeof createInquirySchema>;

--- a/app/src/lib/validations/membership-pipeline.ts
+++ b/app/src/lib/validations/membership-pipeline.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { dateString } from "./common";
+
+const PROSPECT_SOURCES = [
+  "referral", "walk_in", "community_event", "web_inquiry", "crm_import",
+] as const;
+
+const PROSPECT_STAGES = [
+  "identified", "reached_out", "visited", "sponsor_found",
+  "applied", "board_approved", "inducted", "declined",
+] as const;
+
+const ACTIVITY_TYPES = [
+  "stage_change", "note", "call", "email", "meeting", "visit", "other",
+] as const;
+
+export const createProspectSchema = z.object({
+  firstName: z.string().min(1, "First name is required").max(128),
+  lastName: z.string().min(1, "Last name is required").max(128),
+  email: z.string().email().or(z.literal("")).default(""),
+  phone: z.string().max(64).default(""),
+  company: z.string().max(256).default(""),
+  classification: z.string().max(128).default(""),
+  source: z.enum(PROSPECT_SOURCES).default("web_inquiry"),
+  referredBy: z.string().nullable().optional(),
+  sponsorId: z.string().nullable().optional(),
+  stage: z.enum(PROSPECT_STAGES).default("identified"),
+  nextAction: z.string().max(512).default(""),
+  nextActionDue: dateString.nullable().optional(),
+  sourceInquiryId: z.string().nullable().optional(),
+  sourceContactId: z.string().nullable().optional(),
+  notes: z.string().default(""),
+});
+
+export const updateProspectSchema = createProspectSchema.partial();
+
+export const createProspectActivitySchema = z.object({
+  activityType: z.enum(ACTIVITY_TYPES),
+  fromStage: z.string().nullable().optional(),
+  toStage: z.string().nullable().optional(),
+  description: z.string().default(""),
+  activityDate: z.string().optional(),
+});
+
+export type CreateProspectInput = z.infer<typeof createProspectSchema>;
+export type UpdateProspectInput = z.infer<typeof updateProspectSchema>;
+export type CreateProspectActivityInput = z.infer<typeof createProspectActivitySchema>;

--- a/app/src/lib/validations/pages.ts
+++ b/app/src/lib/validations/pages.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const createPageSchema = z.object({
+  slug: z
+    .string()
+    .min(1, "Slug is required")
+    .max(256)
+    .regex(/^[a-z0-9-]+$/, "Slug must be lowercase alphanumeric with hyphens"),
+  title: z.string().min(1, "Title is required").max(512),
+  content: z.string().default(""),
+  metaDescription: z.string().max(512).default(""),
+  published: z.boolean().default(true),
+});
+
+export const updatePageSchema = z.object({
+  title: z.string().min(1).max(512).optional(),
+  content: z.string().optional(),
+  metaDescription: z.string().max(512).optional(),
+  published: z.boolean().optional(),
+});
+
+export type CreatePageInput = z.infer<typeof createPageSchema>;
+export type UpdatePageInput = z.infer<typeof updatePageSchema>;

--- a/app/src/lib/validations/tasks.ts
+++ b/app/src/lib/validations/tasks.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { dateString } from "./common";
+
+const TASK_STATUSES = ["todo", "in_progress", "done", "cancelled"] as const;
+const TASK_PRIORITIES = ["low", "medium", "high", "urgent"] as const;
+
+export const createTaskSchema = z.object({
+  title: z.string().min(1, "Title is required").max(512),
+  description: z.string().default(""),
+  status: z.enum(TASK_STATUSES).default("todo"),
+  priority: z.enum(TASK_PRIORITIES).default("medium"),
+  assignee: z.string().max(128).default("Unassigned"),
+  category: z.string().max(32).default("general"),
+  dueDate: dateString.or(z.literal("")).default(""),
+});
+
+export const updateTaskSchema = createTaskSchema.partial();
+
+export type CreateTaskInput = z.infer<typeof createTaskSchema>;
+export type UpdateTaskInput = z.infer<typeof updateTaskSchema>;

--- a/app/src/lib/validations/vendor-interest.ts
+++ b/app/src/lib/validations/vendor-interest.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const createVendorInterestSchema = z.object({
+  businessName: z.string().min(1, "Business name is required").max(256),
+  contactName: z.string().max(256).default(""),
+  email: z.string().email().or(z.literal("")).default(""),
+  phone: z.string().max(64).default(""),
+  category: z.string().max(32).default(""),
+  website: z.string().url().or(z.literal("")).default(""),
+  description: z.string().default(""),
+  previousParticipant: z.boolean().default(false),
+});
+
+export const processVendorInterestSchema = z.object({
+  convertedBy: z.string().default("Admin"),
+});
+
+export type CreateVendorInterestInput = z.infer<typeof createVendorInterestSchema>;
+export type ProcessVendorInterestInput = z.infer<typeof processVendorInterestSchema>;

--- a/app/src/proxy.ts
+++ b/app/src/proxy.ts
@@ -1,4 +1,10 @@
+import { NextRequest, NextResponse } from "next/server";
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+
+const UNCORKED_DOMAIN = "fullertonuncorked.org";
+
+// Public uncorked domain paths rewritten to /_uc/* internal routes
+const UNCORKED_PUBLIC_PATHS = ["/", "/about", "/schedule", "/tickets", "/gallery", "/faq", "/contact"];
 
 const isPublicRoute = createRouteMatcher([
   "/",
@@ -13,25 +19,47 @@ const isPublicRoute = createRouteMatcher([
   "/vendor-interest(.*)",
   "/login(.*)",
   "/register(.*)",
+  // Internal uncorked pages served via domain rewrite
+  "/_uc(.*)",
   // Public APIs
   "/api/vendor-interest",
   "/api/pages(.*)",
   "/api/membership-inquiries",
-  // Keep this one public — kiosk polls it to show "session active" without auth
+  "/api/public(.*)",
   "/api/checkin/session",
 ]);
 
-export default clerkMiddleware(async (auth, req) => {
+export default clerkMiddleware(async (auth, req: NextRequest) => {
+  const hostname = req.headers.get("host") ?? "";
+  const isUncorkedDomain =
+    hostname === UNCORKED_DOMAIN ||
+    hostname === `www.${UNCORKED_DOMAIN}`;
+
+  if (isUncorkedDomain) {
+    const { pathname } = req.nextUrl;
+
+    // Rewrite public uncorked pages to /_uc/* internal routes
+    if (UNCORKED_PUBLIC_PATHS.includes(pathname)) {
+      const internalPath = pathname === "/" ? "/_uc" : `/_uc${pathname}`;
+      const url = req.nextUrl.clone();
+      url.pathname = internalPath;
+      return NextResponse.rewrite(url);
+    }
+
+    // /sponsors, /vendor-interest, /vendors served directly — no rewrite needed
+    return NextResponse.next();
+  }
+
   if (!isPublicRoute(req)) {
     await auth.protect();
   }
+
+  return NextResponse.next();
 });
 
 export const config = {
   matcher: [
-    // Skip Next.js internals and static files
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
-    // Always run for API routes
     "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
Adds 7 new public pages to the (uncorked) route group: Home, About, Schedule, Tickets, Gallery, FAQ, Contact.

## Changes

- **Home/Landing** — hero section, event details, highlights grid, sponsor logos, ticket CTA
- **About** — event history, Rotary mission, stats, timeline 
- **Schedule** — 10-item event timeline from VIP entry to close
- **Tickets** — General ($75), VIP ($125), DD ($20) tiers; dynamic URLs from EventConfig
- **Gallery** — past event photo gallery with placeholder images
- **FAQ** — parking, age, rain policy, refunds organized by category
- **Contact** — inquiry form storing submissions in the contacts table

## Architecture

Pages live under `(uncorked)/_uc/` (served at `/_uc/*` internally). The domain routing in `proxy.ts` rewrites `fullertonuncorked.org/*` → `/_uc/*`, so users see clean URLs. This avoids Next.js route group path conflicts with the existing `(rotary)` group.

Also adds `/api/public/contact` for unauthenticated form submissions.

Closes #16