### PR TITLE
feat: admin dashboard — key metrics and quick actions

### DIFF
--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -7,15 +7,29 @@ import {
   Inbox,
   CheckCircle,
   TrendingUp,
+  TrendingDown,
   ShieldCheck,
   Megaphone,
   UserPlus,
   ArrowRight,
   BarChart3,
   RefreshCw,
+  Plus,
+  Radio,
+  MapPin,
+  Clock,
 } from "lucide-react";
 import Link from "next/link";
 import { formatDate } from "@/lib/utils";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
 
 interface AdminStats {
   totalMembers: number;
@@ -23,6 +37,9 @@ interface AdminStats {
   newInquiries: number;
   attendanceRate: number;
   uniqueAttendeesThisMonth: number;
+  membersThisMonth: number;
+  membersLastMonth: number;
+  memberTrend: number;
 }
 
 interface RecentAnnouncement {
@@ -41,10 +58,26 @@ interface RecentMember {
   createdAt: string;
 }
 
+interface UpcomingEvent {
+  id: string;
+  title: string;
+  date: string;
+  startTime: string;
+  location: string;
+  category: string;
+}
+
+interface WeeklyAttendance {
+  week: string;
+  count: number;
+}
+
 export default function AdminDashboard() {
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [recentAnnouncements, setRecentAnnouncements] = useState<RecentAnnouncement[]>([]);
   const [recentMembers, setRecentMembers] = useState<RecentMember[]>([]);
+  const [upcomingEvents, setUpcomingEvents] = useState<UpcomingEvent[]>([]);
+  const [weeklyAttendance, setWeeklyAttendance] = useState<WeeklyAttendance[]>([]);
   const [loading, setLoading] = useState(true);
 
   const load = () => {
@@ -55,31 +88,40 @@ export default function AdminDashboard() {
         setStats(data.stats ?? null);
         setRecentAnnouncements(data.recentAnnouncements ?? []);
         setRecentMembers(data.recentMembers ?? []);
+        setUpcomingEvents(data.upcomingEvents ?? []);
+        setWeeklyAttendance(data.weeklyAttendance ?? []);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
   };
 
   useEffect(() => {
-    fetch("/api/admin/stats")
-      .then((r) => r.json())
-      .then((data) => {
-        setStats(data.stats ?? null);
-        setRecentAnnouncements(data.recentAnnouncements ?? []);
-        setRecentMembers(data.recentMembers ?? []);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Format week label as "Mon D" from YYYY-MM-DD
+  const chartData = weeklyAttendance.map((w) => {
+    const d = new Date(w.week + "T00:00:00");
+    return {
+      week: d.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+      attendees: w.count,
+    };
+  });
+
+  const memberTrend = stats?.memberTrend ?? 0;
 
   const statCards = [
     {
       label: "Active Members",
       value: stats?.totalMembers ?? "—",
-      sub: "registered in platform",
+      sub: memberTrend !== 0
+        ? `${memberTrend > 0 ? "+" : ""}${memberTrend}% vs last month`
+        : `${stats?.membersThisMonth ?? 0} joined this month`,
       icon: Users,
       color: "from-blue-500 to-blue-600",
       href: "/admin/members",
+      trend: memberTrend,
     },
     {
       label: "Attendance Rate",
@@ -88,6 +130,7 @@ export default function AdminDashboard() {
       icon: CheckCircle,
       color: "from-emerald-500 to-emerald-600",
       href: "/admin/attendance",
+      trend: null,
     },
     {
       label: "Pending Events",
@@ -96,6 +139,7 @@ export default function AdminDashboard() {
       icon: CalendarDays,
       color: stats?.pendingEvents ? "from-amber-500 to-amber-600" : "from-gray-400 to-gray-500",
       href: "/admin/events",
+      trend: null,
     },
     {
       label: "New Inquiries",
@@ -103,18 +147,64 @@ export default function AdminDashboard() {
       sub: "membership inquiries",
       icon: Inbox,
       color: stats?.newInquiries ? "from-rose-500 to-rose-600" : "from-gray-400 to-gray-500",
-      href: "/admin/members",
+      href: "/admin/membership-pipeline",
+      trend: null,
     },
   ];
 
   const quickActions = [
-    { label: "Invite Member", desc: "Send a Clerk invitation via email", icon: UserPlus, href: "/admin/members", color: "from-blue-500 to-blue-600" },
-    { label: "New Announcement", desc: "Post a club announcement", icon: Megaphone, href: "/admin/announcements", color: "from-purple-500 to-purple-600" },
-    { label: "Attendance Entry", desc: "Record this week's attendance", icon: CheckCircle, href: "/admin/attendance", color: "from-emerald-500 to-emerald-600" },
-    { label: "Review Events", desc: "Approve pending event submissions", icon: CalendarDays, href: "/admin/events", color: "from-amber-500 to-amber-600" },
-    { label: "Member Reports", desc: "View membership and attendance trends", icon: BarChart3, href: "/admin/reports", color: "from-indigo-500 to-indigo-600" },
-    { label: "Admin Settings", desc: "Club information and integrations", icon: ShieldCheck, href: "/admin/settings", color: "from-gray-500 to-gray-600" },
+    {
+      label: "Create Event",
+      desc: "Add a new club event",
+      icon: Plus,
+      href: "/admin/events",
+      color: "from-amber-500 to-amber-600",
+    },
+    {
+      label: "Send Broadcast",
+      desc: "Message all members",
+      icon: Radio,
+      href: "/admin/messaging",
+      color: "from-purple-500 to-purple-600",
+    },
+    {
+      label: "Add Member",
+      desc: "Invite a new member via email",
+      icon: UserPlus,
+      href: "/admin/members",
+      color: "from-blue-500 to-blue-600",
+    },
+    {
+      label: "New Announcement",
+      desc: "Post a club announcement",
+      icon: Megaphone,
+      href: "/admin/announcements",
+      color: "from-indigo-500 to-indigo-600",
+    },
+    {
+      label: "Attendance Entry",
+      desc: "Record this week's attendance",
+      icon: CheckCircle,
+      href: "/admin/attendance",
+      color: "from-emerald-500 to-emerald-600",
+    },
+    {
+      label: "View Reports",
+      desc: "Membership and attendance trends",
+      icon: BarChart3,
+      href: "/admin/reports",
+      color: "from-gray-500 to-gray-600",
+    },
   ];
+
+  const categoryColors: Record<string, string> = {
+    meeting: "bg-blue-50 text-blue-700",
+    service: "bg-green-50 text-green-700",
+    social: "bg-pink-50 text-pink-700",
+    fundraiser: "bg-yellow-50 text-yellow-700",
+    speaker: "bg-purple-50 text-purple-700",
+    general: "bg-gray-100 text-gray-600",
+  };
 
   return (
     <div className="space-y-8">
@@ -142,12 +232,34 @@ export default function AdminDashboard() {
       {/* Stats Grid */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {statCards.map((card) => (
-          <Link key={card.label} href={card.href} className="group rounded-xl bg-white border border-gray-200 p-5 hover:shadow-md transition-all">
+          <Link
+            key={card.label}
+            href={card.href}
+            className="group rounded-xl bg-white border border-gray-200 p-5 hover:shadow-md transition-all"
+          >
             <div className="flex items-start justify-between mb-4">
-              <div className={`w-10 h-10 rounded-lg bg-gradient-to-br ${card.color} flex items-center justify-center shadow-sm`}>
+              <div
+                className={`w-10 h-10 rounded-lg bg-gradient-to-br ${card.color} flex items-center justify-center shadow-sm`}
+              >
                 <card.icon className="w-[18px] h-[18px] text-white" />
               </div>
-              <ArrowRight className="w-4 h-4 text-gray-300 group-hover:text-blue-500 transition-colors mt-1" />
+              <div className="flex items-center gap-1">
+                {card.trend !== null && card.trend !== 0 && (
+                  <span
+                    className={`flex items-center gap-0.5 text-xs font-medium ${
+                      card.trend > 0 ? "text-emerald-600" : "text-rose-600"
+                    }`}
+                  >
+                    {card.trend > 0 ? (
+                      <TrendingUp className="w-3.5 h-3.5" />
+                    ) : (
+                      <TrendingDown className="w-3.5 h-3.5" />
+                    )}
+                    {Math.abs(card.trend)}%
+                  </span>
+                )}
+                <ArrowRight className="w-4 h-4 text-gray-300 group-hover:text-blue-500 transition-colors mt-0.5" />
+              </div>
             </div>
             <p className="text-2xl font-bold text-gray-900">
               {loading ? (
@@ -162,7 +274,71 @@ export default function AdminDashboard() {
         ))}
       </div>
 
-      {/* Quick Actions + Recent Activity */}
+      {/* Attendance Chart */}
+      <div className="rounded-xl bg-white border border-gray-200 p-5">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-base font-semibold text-gray-900">Attendance — Last 12 Weeks</h2>
+            <p className="text-xs text-gray-500 mt-0.5">Unique attendees per week</p>
+          </div>
+          <Link
+            href="/admin/attendance"
+            className="text-xs text-blue-600 hover:underline flex items-center gap-1"
+          >
+            Full history <ArrowRight className="w-3 h-3" />
+          </Link>
+        </div>
+        {loading ? (
+          <div className="h-48 rounded-lg bg-gray-50 animate-pulse" />
+        ) : chartData.length === 0 ? (
+          <div className="h-48 flex items-center justify-center text-sm text-gray-400">
+            No attendance data yet
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={192}>
+            <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+              <defs>
+                <linearGradient id="attendanceGrad" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#10b981" stopOpacity={0.2} />
+                  <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <XAxis
+                dataKey="week"
+                tick={{ fontSize: 11, fill: "#9ca3af" }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tick={{ fontSize: 11, fill: "#9ca3af" }}
+                axisLine={false}
+                tickLine={false}
+                allowDecimals={false}
+              />
+              <Tooltip
+                contentStyle={{
+                  borderRadius: "8px",
+                  border: "1px solid #e5e7eb",
+                  fontSize: "12px",
+                }}
+                formatter={(v: number | undefined) => [v ?? 0, "Attendees"]}
+              />
+              <Area
+                type="monotone"
+                dataKey="attendees"
+                stroke="#10b981"
+                strokeWidth={2}
+                fill="url(#attendanceGrad)"
+                dot={{ r: 3, fill: "#10b981", strokeWidth: 0 }}
+                activeDot={{ r: 5 }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Quick Actions + Upcoming Events */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Quick Actions */}
         <div>
@@ -174,7 +350,9 @@ export default function AdminDashboard() {
                 href={action.href}
                 className="group flex items-center gap-4 p-3.5 rounded-xl bg-white border border-gray-200 hover:border-blue-200 hover:shadow-sm transition-all"
               >
-                <div className={`w-9 h-9 rounded-lg bg-gradient-to-br ${action.color} flex items-center justify-center shrink-0`}>
+                <div
+                  className={`w-9 h-9 rounded-lg bg-gradient-to-br ${action.color} flex items-center justify-center shrink-0`}
+                >
                   <action.icon className="w-[18px] h-[18px] text-white" />
                 </div>
                 <div className="flex-1 min-w-0">
@@ -187,51 +365,79 @@ export default function AdminDashboard() {
           </div>
         </div>
 
-        {/* Recent Activity */}
+        {/* Upcoming Events (next 7 days) + Recent Announcements */}
         <div className="space-y-6">
-          {/* Recent Members */}
+          {/* Upcoming Events */}
           <div>
             <div className="flex items-center justify-between mb-3">
-              <h2 className="text-base font-semibold text-gray-900">Recent Members</h2>
-              <Link href="/admin/members" className="text-xs text-blue-600 hover:underline">View all</Link>
+              <h2 className="text-base font-semibold text-gray-900">Upcoming Events</h2>
+              <Link href="/admin/events" className="text-xs text-blue-600 hover:underline">
+                View all
+              </Link>
             </div>
             <div className="rounded-xl bg-white border border-gray-200 overflow-hidden">
               {loading ? (
                 <div className="divide-y divide-gray-100">
                   {[...Array(3)].map((_, i) => (
                     <div key={i} className="flex items-center gap-3 p-3.5">
-                      <div className="w-8 h-8 rounded-full bg-gray-100 animate-pulse shrink-0" />
+                      <div className="w-10 h-10 rounded-lg bg-gray-100 animate-pulse shrink-0" />
                       <div className="flex-1 space-y-1.5">
-                        <div className="h-3.5 rounded bg-gray-100 animate-pulse w-32" />
-                        <div className="h-3 rounded bg-gray-100 animate-pulse w-48" />
+                        <div className="h-3.5 rounded bg-gray-100 animate-pulse w-36" />
+                        <div className="h-3 rounded bg-gray-100 animate-pulse w-24" />
                       </div>
                     </div>
                   ))}
                 </div>
-              ) : recentMembers.length === 0 ? (
-                <p className="text-sm text-gray-400 p-4 text-center">No members yet</p>
+              ) : upcomingEvents.length === 0 ? (
+                <p className="text-sm text-gray-400 p-4 text-center">
+                  No events in the next 7 days
+                </p>
               ) : (
                 <div className="divide-y divide-gray-100">
-                  {recentMembers.map((m) => (
-                    <div key={m.id} className="flex items-center gap-3 p-3.5">
-                      <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0">
-                        <span className="text-xs font-bold text-white">
-                          {(m.firstName[0] ?? "") + (m.lastName[0] ?? "")}
+                  {upcomingEvents.map((ev) => {
+                    const d = new Date(ev.date + "T00:00:00");
+                    const dayStr = d.toLocaleDateString("en-US", {
+                      weekday: "short",
+                      month: "short",
+                      day: "numeric",
+                    });
+                    return (
+                      <div key={ev.id} className="flex items-center gap-3 p-3.5">
+                        <div className="w-10 h-10 rounded-lg bg-amber-50 flex flex-col items-center justify-center shrink-0">
+                          <span className="text-[10px] font-bold text-amber-600 uppercase leading-none">
+                            {d.toLocaleDateString("en-US", { month: "short" })}
+                          </span>
+                          <span className="text-sm font-bold text-amber-700 leading-none">
+                            {d.getDate()}
+                          </span>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-900 truncate">{ev.title}</p>
+                          <div className="flex items-center gap-2 mt-0.5">
+                            {ev.startTime && (
+                              <span className="flex items-center gap-0.5 text-xs text-gray-500">
+                                <Clock className="w-3 h-3" />
+                                {ev.startTime}
+                              </span>
+                            )}
+                            {ev.location && (
+                              <span className="flex items-center gap-0.5 text-xs text-gray-500 truncate">
+                                <MapPin className="w-3 h-3 shrink-0" />
+                                {ev.location}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <span
+                          className={`text-[10px] px-2 py-0.5 rounded-full font-medium capitalize shrink-0 ${
+                            categoryColors[ev.category] ?? "bg-gray-100 text-gray-600"
+                          }`}
+                        >
+                          {ev.category}
                         </span>
                       </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-900 truncate">
-                          {m.firstName} {m.lastName}
-                        </p>
-                        <p className="text-xs text-gray-500 truncate">{m.email}</p>
-                      </div>
-                      <div className="shrink-0">
-                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 font-medium capitalize">
-                          {m.memberType}
-                        </span>
-                      </div>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>
@@ -241,7 +447,9 @@ export default function AdminDashboard() {
           <div>
             <div className="flex items-center justify-between mb-3">
               <h2 className="text-base font-semibold text-gray-900">Recent Announcements</h2>
-              <Link href="/admin/announcements" className="text-xs text-blue-600 hover:underline">View all</Link>
+              <Link href="/admin/announcements" className="text-xs text-blue-600 hover:underline">
+                View all
+              </Link>
             </div>
             <div className="rounded-xl bg-white border border-gray-200 overflow-hidden">
               {loading ? (
@@ -269,11 +477,15 @@ export default function AdminDashboard() {
                         <p className="text-sm font-medium text-gray-900 truncate">{a.title}</p>
                         <p className="text-xs text-gray-500">{formatDate(a.createdAt)}</p>
                       </div>
-                      <span className={`text-[10px] px-2 py-0.5 rounded-full font-medium capitalize shrink-0 ${
-                        a.category === "urgent" ? "bg-red-50 text-red-700" :
-                        a.category === "event" ? "bg-blue-50 text-blue-700" :
-                        "bg-gray-100 text-gray-600"
-                      }`}>
+                      <span
+                        className={`text-[10px] px-2 py-0.5 rounded-full font-medium capitalize shrink-0 ${
+                          a.category === "urgent"
+                            ? "bg-red-50 text-red-700"
+                            : a.category === "event"
+                            ? "bg-blue-50 text-blue-700"
+                            : "bg-gray-100 text-gray-600"
+                        }`}
+                      >
                         {a.category}
                       </span>
                     </div>
@@ -285,25 +497,51 @@ export default function AdminDashboard() {
         </div>
       </div>
 
-      {/* Trends teaser */}
-      <div className="rounded-xl bg-gradient-to-br from-gray-900 to-gray-800 p-6 text-white">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-amber-500/20 flex items-center justify-center">
-              <TrendingUp className="w-5 h-5 text-amber-400" />
-            </div>
-            <div>
-              <h2 className="text-base font-semibold">Membership & Attendance Trends</h2>
-              <p className="text-sm text-gray-400">Full reports with Recharts visualizations</p>
-            </div>
-          </div>
-          <Link
-            href="/admin/reports"
-            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-400 text-gray-900 text-sm font-semibold transition-colors"
-          >
-            View Reports
-            <ArrowRight className="w-4 h-4" />
+      {/* Recent Members */}
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-base font-semibold text-gray-900">Recently Joined Members</h2>
+          <Link href="/admin/members" className="text-xs text-blue-600 hover:underline">
+            View all
           </Link>
+        </div>
+        <div className="rounded-xl bg-white border border-gray-200 overflow-hidden">
+          {loading ? (
+            <div className="divide-y divide-gray-100">
+              {[...Array(3)].map((_, i) => (
+                <div key={i} className="flex items-center gap-3 p-3.5">
+                  <div className="w-8 h-8 rounded-full bg-gray-100 animate-pulse shrink-0" />
+                  <div className="flex-1 space-y-1.5">
+                    <div className="h-3.5 rounded bg-gray-100 animate-pulse w-32" />
+                    <div className="h-3 rounded bg-gray-100 animate-pulse w-48" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : recentMembers.length === 0 ? (
+            <p className="text-sm text-gray-400 p-4 text-center">No members yet</p>
+          ) : (
+            <div className="divide-y divide-gray-100">
+              {recentMembers.map((m) => (
+                <div key={m.id} className="flex items-center gap-3 p-3.5">
+                  <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-blue-600 flex items-center justify-center shrink-0">
+                    <span className="text-xs font-bold text-white">
+                      {(m.firstName[0] ?? "") + (m.lastName[0] ?? "")}
+                    </span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      {m.firstName} {m.lastName}
+                    </p>
+                    <p className="text-xs text-gray-500 truncate">{m.email}</p>
+                  </div>
+                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-blue-50 text-blue-700 font-medium capitalize shrink-0">
+                    {m.memberType}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/app/src/app/api/admin/stats/route.ts
+++ b/app/src/app/api/admin/stats/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { hasAnyRole } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { users, events, membershipInquiries, announcements, attendance } from "@/lib/db/schema";
-import { eq, sql, gte, desc } from "drizzle-orm";
+import { eq, sql, gte, lte, and, desc, between } from "drizzle-orm";
 
 export async function GET() {
   const { userId } = await auth();
@@ -14,7 +14,27 @@ export async function GET() {
 
   try {
     const now = new Date();
+
+    // Date helpers
+    const todayStr = now.toISOString().split("T")[0];
+    const in7Days = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0];
+
     const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+      .toISOString()
+      .split("T")[0];
+
+    // Last month window for member trend
+    const firstOfLastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1)
+      .toISOString();
+    const endOfLastMonth = new Date(now.getFullYear(), now.getMonth(), 0, 23, 59, 59)
+      .toISOString();
+    const firstOfThisMonth = new Date(now.getFullYear(), now.getMonth(), 1)
+      .toISOString();
+
+    // Last 12 weeks for attendance chart
+    const twelveWeeksAgo = new Date(now.getTime() - 12 * 7 * 24 * 60 * 60 * 1000)
       .toISOString()
       .split("T")[0];
 
@@ -25,6 +45,10 @@ export async function GET() {
       recentAnnouncements,
       recentMembers,
       monthAttendance,
+      membersThisMonth,
+      membersLastMonth,
+      upcomingEvents,
+      weeklyAttendanceRaw,
     ] = await Promise.all([
       // Total active members
       db
@@ -49,14 +73,26 @@ export async function GET() {
 
       // Recent announcements (last 5)
       db
-        .select({ id: announcements.id, title: announcements.title, category: announcements.category, createdAt: announcements.createdAt })
+        .select({
+          id: announcements.id,
+          title: announcements.title,
+          category: announcements.category,
+          createdAt: announcements.createdAt,
+        })
         .from(announcements)
         .orderBy(desc(announcements.createdAt))
         .limit(5),
 
       // Recently joined members (last 5)
       db
-        .select({ id: users.id, firstName: users.firstName, lastName: users.lastName, email: users.email, memberType: users.memberType, createdAt: users.createdAt })
+        .select({
+          id: users.id,
+          firstName: users.firstName,
+          lastName: users.lastName,
+          email: users.email,
+          memberType: users.memberType,
+          createdAt: users.createdAt,
+        })
         .from(users)
         .orderBy(desc(users.createdAt))
         .limit(5),
@@ -66,12 +102,71 @@ export async function GET() {
         .select({ userId: attendance.userId })
         .from(attendance)
         .where(gte(attendance.date, firstOfMonth)),
+
+      // Members added this month (for trend)
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(users)
+        .where(gte(users.createdAt, new Date(firstOfThisMonth)))
+        .then((r) => r[0]?.count ?? 0),
+
+      // Members added last month (for trend)
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(users)
+        .where(
+          and(
+            gte(users.createdAt, new Date(firstOfLastMonth)),
+            lte(users.createdAt, new Date(endOfLastMonth))
+          )
+        )
+        .then((r) => r[0]?.count ?? 0),
+
+      // Upcoming approved events (next 7 days)
+      db
+        .select({
+          id: events.id,
+          title: events.title,
+          date: events.date,
+          startTime: events.startTime,
+          location: events.location,
+          category: events.category,
+        })
+        .from(events)
+        .where(
+          and(
+            eq(events.status, "approved"),
+            gte(events.date, todayStr),
+            lte(events.date, in7Days)
+          )
+        )
+        .orderBy(events.date)
+        .limit(5),
+
+      // Weekly attendance counts (last 12 weeks) — group by ISO week
+      db
+        .select({
+          week: sql<string>`to_char(date_trunc('week', ${attendance.date}::date), 'YYYY-MM-DD')`,
+          count: sql<number>`count(distinct ${attendance.userId})::int`,
+        })
+        .from(attendance)
+        .where(gte(attendance.date, twelveWeeksAgo))
+        .groupBy(sql`date_trunc('week', ${attendance.date}::date)`)
+        .orderBy(sql`date_trunc('week', ${attendance.date}::date)`),
     ]);
 
     // Attendance rate: unique attendees this month / total active members
     const uniqueAttendees = new Set(monthAttendance.map((a) => a.userId)).size;
     const attendanceRate =
       totalMembers > 0 ? Math.round((uniqueAttendees / totalMembers) * 100) : 0;
+
+    // Member trend: new members this month vs last month
+    const memberTrend =
+      membersLastMonth > 0
+        ? Math.round(((membersThisMonth - membersLastMonth) / membersLastMonth) * 100)
+        : membersThisMonth > 0
+        ? 100
+        : 0;
 
     return NextResponse.json({
       stats: {
@@ -80,9 +175,14 @@ export async function GET() {
         newInquiries,
         attendanceRate,
         uniqueAttendeesThisMonth: uniqueAttendees,
+        membersThisMonth,
+        membersLastMonth,
+        memberTrend,
       },
       recentAnnouncements,
       recentMembers,
+      upcomingEvents,
+      weeklyAttendance: weeklyAttendanceRaw,
     });
   } catch (err) {
     console.error("Admin stats error:", err);
@@ -93,9 +193,14 @@ export async function GET() {
         newInquiries: 0,
         attendanceRate: 0,
         uniqueAttendeesThisMonth: 0,
+        membersThisMonth: 0,
+        membersLastMonth: 0,
+        memberTrend: 0,
       },
       recentAnnouncements: [],
       recentMembers: [],
+      upcomingEvents: [],
+      weeklyAttendance: [],
     });
   }
 }


### PR DESCRIPTION
Closes #37

Adds an enhanced metrics dashboard to the admin home page:

- **Member trend**: active member count with +/-% vs last month
- **Attendance chart**: inline recharts AreaChart — unique attendees over last 12 weeks
- **Upcoming events**: next 7 days (approved events, date/time/location)
- **Pending inquiries**: count with direct link to membership pipeline
- **Quick actions**: Create Event, Send Broadcast, Add Member (+ Announcement, Attendance, Reports)
- **Recent announcements** and **recently joined members**
- Mobile-responsive card grid throughout

API () updated to return: member trend, upcoming events, weekly attendance series.