### PR TITLE
feat: toast notifications replacing alert() calls

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -36,6 +36,7 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "recharts": "^3.7.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -10753,6 +10754,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/app/package.json
+++ b/app/package.json
@@ -41,6 +41,7 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/app/src/app/(kiosk)/checkin/page.tsx
+++ b/app/src/app/(kiosk)/checkin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { toast } from "sonner";
 
 interface Member {
   id: string;
@@ -43,7 +44,7 @@ export default function CheckinPage() {
       }
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       setSessionActive(false);
     }
   }, []);
@@ -77,7 +78,7 @@ export default function CheckinPage() {
         setNoResults((data.members ?? []).length === 0);
       } catch (error) {
         console.error('Request failed:', error);
-        alert('Something went wrong. Please try again.');
+        toast.error('Something went wrong. Please try again.');
         setMembers([]);
         setNoResults(false);
       } finally {
@@ -114,7 +115,7 @@ export default function CheckinPage() {
       }
     } catch (error) {
       console.error('Operation failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       setOverlay({ type: "none" });
     }
   };

--- a/app/src/app/admin/attendance/page.tsx
+++ b/app/src/app/admin/attendance/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useEffect, useState, useCallback } from "react";
 import {
   ClipboardList,
@@ -79,7 +80,7 @@ export default function AttendanceReportsPage() {
       setTimeout(() => setSaveResult(null), 3000);
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       setSaveResult("error");
     } finally {
       setSaving(false);

--- a/app/src/app/admin/committees/page.tsx
+++ b/app/src/app/admin/committees/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useEffect, useState, useCallback } from "react";
 import {
   Building2,
@@ -195,7 +196,7 @@ export default function CommitteeManagementPage() {
       setCommitteeMembers(data.members ?? []);
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // silently fail — UI remains in sync since we don't optimistically update
     }
   }
@@ -213,7 +214,7 @@ export default function CommitteeManagementPage() {
       }
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // silently fail — re-fetch to stay in sync
       const data = await fetch(`/api/admin/committees/${selected.id}?members=true`).then((r) => r.json());
       setCommitteeMembers(data.members ?? []);
@@ -232,7 +233,7 @@ export default function CommitteeManagementPage() {
       load();
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // silently fail
     }
   }

--- a/app/src/app/admin/members/page.tsx
+++ b/app/src/app/admin/members/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useEffect, useState, useMemo, useCallback } from "react";
 import {
   Users,
@@ -418,7 +419,7 @@ function ImportModal({ onClose, onImported }: { onClose: () => void; onImported:
       setPreview(data.rows ?? []);
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       setError("Failed to parse CSV");
     } finally {
       setPreviewing(false);
@@ -438,7 +439,7 @@ function ImportModal({ onClose, onImported }: { onClose: () => void; onImported:
       onImported();
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       setError("Import failed");
     } finally {
       setImporting(false);

--- a/app/src/app/admin/membership-pipeline/[id]/page.tsx
+++ b/app/src/app/admin/membership-pipeline/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useState, useEffect, use } from "react";
 import Link from "next/link";
 import {
@@ -125,7 +126,7 @@ export default function ProspectDetailPage({
       }
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     } finally {
       setSaving(false);
@@ -141,7 +142,7 @@ export default function ProspectDetailPage({
       if (res.ok) window.location.href = "/admin/membership-pipeline";
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     }
   };
@@ -613,7 +614,7 @@ function AddActivityModal({
       if (res.ok) onCreated();
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     } finally {
       setSaving(false);

--- a/app/src/app/admin/membership-pipeline/page.tsx
+++ b/app/src/app/admin/membership-pipeline/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useState, useEffect, useCallback, type DragEvent } from "react";
 import Link from "next/link";
 import {
@@ -72,7 +73,7 @@ export default function MembershipPipelinePage() {
       if (res.ok) setProspects(await res.json());
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     } finally {
       setLoading(false);
@@ -98,7 +99,7 @@ export default function MembershipPipelinePage() {
       });
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       fetchProspects(); // revert
     }
   };
@@ -432,7 +433,7 @@ function AddProspectModal({
       if (res.ok) onCreated();
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     } finally {
       setSaving(false);

--- a/app/src/app/admin/website/page.tsx
+++ b/app/src/app/admin/website/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useState, useEffect, useCallback } from "react";
 import React from "react";
 import {
@@ -170,7 +171,7 @@ export default function WebsiteCmsPage() {
       }
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       setSaveStatus("error");
     } finally {
       setSaving(false);

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -150,3 +150,22 @@ body {
   font-weight: 500;
   line-height: 20px;
 }
+
+/* Rotary brand toast styles */
+.rotary-toast {
+  border-radius: 8px !important;
+  font-family: var(--font-geist-sans), sans-serif;
+}
+.rotary-toast-success {
+  background: #003F8A !important;
+  color: #ffffff !important;
+  border-color: #003F8A !important;
+}
+.rotary-toast-error {
+  border-color: #c0392b !important;
+}
+.rotary-toast-warning {
+  background: #F5A623 !important;
+  color: #1a1a1a !important;
+  border-color: #F5A623 !important;
+}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
+import { Toaster } from "sonner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,6 +29,7 @@ export default function RootLayout({
       <html lang="en">
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
           {children}
+          <Toaster richColors position="top-right" />
         </body>
       </html>
     </ClerkProvider>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
       <html lang="en">
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
           {children}
-          <Toaster richColors position="top-right" />
+          <Toaster richColors position="bottom-right" duration={5000} toastOptions={{ classNames: { toast: "rotary-toast", error: "rotary-toast-error", success: "rotary-toast-success", warning: "rotary-toast-warning" } }} />
         </body>
       </html>
     </ClerkProvider>

--- a/app/src/app/portal/bryn/page.tsx
+++ b/app/src/app/portal/bryn/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useUser } from "@clerk/nextjs";
 import {
@@ -107,7 +108,7 @@ export default function BrynChatPage() {
       setShowSidebar(false);
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     }
   };

--- a/app/src/app/portal/checkin/page.tsx
+++ b/app/src/app/portal/checkin/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useUser } from "@clerk/nextjs";
 
@@ -117,7 +118,7 @@ export default function CheckinMonitorPage() {
           }
         } catch (error) {
           console.error('Request failed:', error);
-          alert('Something went wrong. Please try again.');
+          toast.error('Something went wrong. Please try again.');
           // ignore
         }
       } else {
@@ -125,7 +126,7 @@ export default function CheckinMonitorPage() {
       }
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore network errors
     }
   }, []);
@@ -160,7 +161,7 @@ export default function CheckinMonitorPage() {
         }
       } catch (error) {
         console.error('Request failed:', error);
-        alert('Something went wrong. Please try again.');
+        toast.error('Something went wrong. Please try again.');
         setManualMembers([]);
       } finally {
         setManualSearching(false);
@@ -184,7 +185,7 @@ export default function CheckinMonitorPage() {
       }
     } catch (error) {
       console.error('Operation failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     }
   };

--- a/app/src/app/portal/profile/page.tsx
+++ b/app/src/app/portal/profile/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useState, useEffect } from "react";
 import * as Avatar from "@radix-ui/react-avatar";
 import { UserCircle, Save, Loader2, CheckCircle2, Camera } from "lucide-react";
@@ -91,7 +92,7 @@ export default function ProfilePage() {
           return JSON.parse(profile.roles);
         } catch (error) {
           console.error('Operation failed:', error);
-          alert('Something went wrong. Please try again.');
+          toast.error('Something went wrong. Please try again.');
           return ["member"];
         }
       })()

--- a/app/src/app/uncorked-hub/vendor-interest/page.tsx
+++ b/app/src/app/uncorked-hub/vendor-interest/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useEffect, useState } from "react";
 import {
   Inbox,
@@ -63,7 +64,7 @@ export default function VendorInterestPage() {
       }
     } catch (error) {
       console.error('Request failed:', error);
-      alert('Something went wrong. Please try again.');
+      toast.error('Something went wrong. Please try again.');
       // ignore
     } finally {
       setLoading(false);

--- a/app/src/app/uncorked-hub/vendors/page.tsx
+++ b/app/src/app/uncorked-hub/vendors/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import {
   Store,
@@ -659,7 +660,7 @@ export default function VendorsPage() {
         return await res.json() as Contact;
       } catch (error) {
         console.error('Request failed:', error);
-        alert('Something went wrong. Please try again.');
+        toast.error('Something went wrong. Please try again.');
         return null;
       }
     });

--- a/app/src/app/uncorked-hub/vendors/page.tsx
+++ b/app/src/app/uncorked-hub/vendors/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { toast } from "sonner";
+import { toast as sonnerToast } from "sonner";
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import {
   Store,
@@ -210,7 +210,7 @@ export default function VendorsPage() {
   const [showEmailModal, setShowEmailModal] = useState(false);
   const [emailSubject, setEmailSubject] = useState("");
   const [emailBody, setEmailBody] = useState("");
-  const [toast, setToast] = useState<string | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [draggedVendorId, setDraggedVendorId] = useState<string | null>(null);
   const [newActivityType, setNewActivityType] = useState<ActivityType>("note");
   const [newActivityDesc, setNewActivityDesc] = useState("");
@@ -252,8 +252,8 @@ export default function VendorsPage() {
 
   // Toast handler
   const showToast = useCallback((message: string) => {
-    setToast(message);
-    setTimeout(() => setToast(null), 3000);
+    setToastMessage(message);
+    setTimeout(() => setToastMessage(null), 3000);
   }, []);
 
   // Filtered vendors
@@ -660,7 +660,7 @@ export default function VendorsPage() {
         return await res.json() as Contact;
       } catch (error) {
         console.error('Request failed:', error);
-        toast.error('Something went wrong. Please try again.');
+        sonnerToast.error('Something went wrong. Please try again.');
         return null;
       }
     });
@@ -709,11 +709,11 @@ export default function VendorsPage() {
   return (
     <div className="animate-fade-in">
       {/* Toast */}
-      {toast && (
+      {toastMessage && (
         <div className="fixed top-6 right-6 z-[100] animate-fade-in">
           <div className="flex items-center gap-2 px-4 py-3 rounded-xl bg-wine-900 text-white shadow-lg text-sm font-medium">
             <CheckCircle2 className="w-4 h-4 text-gold-400 shrink-0" />
-            {toast}
+            {toastMessage}
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #39

Installs sonner (already at ^2.0.7), configures Toaster in root layout, replaces all alert() calls with typed toast calls, and applies Rotary brand colors.

**Changes:**
- Toaster: `position=bottom-right`, `duration=5000`, `richColors`
- Brand CSS: success → Rotary blue (#003F8A), warning → gold (#F5A623)
- Fixed shadowed `toast` state variable in vendors/page.tsx (renamed to `toastMessage`)